### PR TITLE
Add code coverage using Codecov

### DIFF
--- a/.github/workflows/auto_test.yaml
+++ b/.github/workflows/auto_test.yaml
@@ -36,15 +36,13 @@ jobs:
     - name: Building TChem (${{ matrix.build-type }}, ${{ matrix.sacado-on }} sacado)
       run: docker build -f Dockerfile -t tchem . --build-arg BUILD_TYPE=${{ matrix.build-type }} --build-arg SACADO=${{ matrix.sacado-on }}
     - name: Testing TChem
-      run: docker run -t tchem bash -c 'cd /tchem_build; ctest'
-    - name: Evaluating code coverage
-      run: docker run -t tchem bash -c 'cd /tchem_build; make coverage'
+      run: docker run -t tchem bash -c 'cd /tchem_build; ctest; make coverage'
     - name: Uploading coverage report to codecov.io
       if: ${{ (contains(matrix.os, 'ubuntu')) && (matrix.build-type == 'Debug') && (matrix.sacado-on == 'OFF') }}
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true
-        files: tchem_build/coverage.info
+        files: /tchem_build/coverage.info
         name: TChem-atm
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true

--- a/.github/workflows/auto_test.yaml
+++ b/.github/workflows/auto_test.yaml
@@ -36,13 +36,13 @@ jobs:
     - name: Building TChem (${{ matrix.build-type }}, ${{ matrix.sacado-on }} sacado)
       run: docker build -f Dockerfile -t tchem . --build-arg BUILD_TYPE=${{ matrix.build-type }} --build-arg SACADO=${{ matrix.sacado-on }}
     - name: Testing TChem
-      run: docker run -t tchem bash -c 'cd /tchem_build; ctest; make coverage'
+      run: docker run -t -v "$PWD:/shared" tchem bash -c 'cd /tchem_build; ctest; make coverage; mv coverage.info /shared'
     - name: Uploading coverage report to codecov.io
       if: ${{ (contains(matrix.os, 'ubuntu')) && (matrix.build-type == 'Debug') && (matrix.sacado-on == 'OFF') }}
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true
-        files: /tchem_build/coverage.info
+        files: coverage.info
         name: TChem-atm
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true

--- a/.github/workflows/auto_test.yaml
+++ b/.github/workflows/auto_test.yaml
@@ -39,3 +39,12 @@ jobs:
       run: docker run -t tchem bash -c 'cd /tchem_build; ctest'
     - name: Evaluating code coverage
       run: docker run -t tchem bash -c 'cd /tchem_build; make coverage'
+    - name: Uploading coverage report to codecov.io
+      if: ${{ (contains(matrix.os, 'ubuntu-22.04')) && (matrix.build-type == 'Debug') && (matrix.sacado-on == 'OFF') }}
+      uses: codecov/codecov-action@v3
+      with:
+        fail_ci_if_error: true
+        files: build/coverage.info
+        name: TChem-atm
+        token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true

--- a/.github/workflows/auto_test.yaml
+++ b/.github/workflows/auto_test.yaml
@@ -40,11 +40,11 @@ jobs:
     - name: Evaluating code coverage
       run: docker run -t tchem bash -c 'cd /tchem_build; make coverage'
     - name: Uploading coverage report to codecov.io
-      if: ${{ (contains(matrix.os, 'ubuntu-22.04')) && (matrix.build-type == 'Debug') && (matrix.sacado-on == 'OFF') }}
+      if: ${{ (contains(matrix.os, 'ubuntu')) && (matrix.build-type == 'Debug') && (matrix.sacado-on == 'OFF') }}
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true
-        files: build/coverage.info
+        files: tchem_build/coverage.info
         name: TChem-atm
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true

--- a/.github/workflows/auto_test.yaml
+++ b/.github/workflows/auto_test.yaml
@@ -37,3 +37,5 @@ jobs:
       run: docker build -f Dockerfile -t tchem . --build-arg BUILD_TYPE=${{ matrix.build-type }} --build-arg SACADO=${{ matrix.sacado-on }}
     - name: Testing TChem
       run: docker run -t tchem bash -c 'cd /tchem_build; ctest'
+    - name: Evaluating code coverage
+      run: docker run -t tchem-coverage bash -c 'cd /tchem_build; make coverage'

--- a/.github/workflows/auto_test.yaml
+++ b/.github/workflows/auto_test.yaml
@@ -38,4 +38,4 @@ jobs:
     - name: Testing TChem
       run: docker run -t tchem bash -c 'cd /tchem_build; ctest'
     - name: Evaluating code coverage
-      run: docker run -t tchem-coverage bash -c 'cd /tchem_build; make coverage'
+      run: docker run -t tchem bash -c 'cd /tchem_build; make coverage'

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
         pkg-config \
         ca-certificates
 
-RUN pip install numpy h5py 
+RUN pip install numpy h5py
 
 COPY . /tchem_dir/
 
@@ -137,7 +137,6 @@ RUN cmake -S /tchem_dir/src -B /tchem_build \
           -DSKYWALKER_INSTALL_PATH=/install/skywalker_install \
           -DTCHEM_ATM_ENABLE_KOKKOSKERNELS=ON \
           -DKOKKOSKERNELS_INSTALL_PATH=/install/kokkoskernels_install \
-          -DTCHEM_ATM_ENABLE_SKYWALKER=ON \
           -DGTEST_INSTALL_PATH=/install/gtest_install
 WORKDIR /tchem_build
 RUN make -j \

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,7 @@ RUN cmake -S /tchem_dir/src -B /tchem_build \
           -DTCHEM_ATM_ENABLE_TEST=ON \
           -DTCHEM_ATM_ENABLE_EXAMPLE=ON \
           -DTCHEM_ATM_ENABLE_SACADO_JACOBIAN_ATMOSPHERIC_CHEMISTRY=${SACADO} \
+          -DTCHEM_ATM_ENABLE_COVERAGE=ON \
           -DKOKKOS_INSTALL_PATH=/install/kokkos_install \
           -DTINES_INSTALL_PATH=/install/tines_install \
           -DTCHEM_ATM_ENABLE_SKYWALKER=ON \

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+# This file configures CodeCov to require 90% code coverage. New PRs can
+# increase or decrease coverage--only the total coverage threshold matters.
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+    patch: off # we can enable this if we figure out a reasonable policy

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,5 +4,5 @@ coverage:
   status:
     project:
       default:
-        target: 90%
+        target: 80%
     patch: off # we can enable this if we figure out a reasonable policy

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
-# This file configures CodeCov to require 90% code coverage. New PRs can
+# This file configures CodeCov to require 80% code coverage. New PRs can
 # increase or decrease coverage--only the total coverage threshold matters.
 coverage:
   status:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ OPTION(TCHEM_ATM_ENABLE_INSTALL "Flag to enable install exports for TCHEM_ATM" O
 OPTION(TCHEM_ATM_ENABLE_SACADO_JACOBIAN_ATMOSPHERIC_CHEMISTRY "Flag to enable sacado jacobian for atmospheric chemistry" OFF)
 OPTION(TCHEM_ATM_ENABLE_SKYWALKER "Flag to enable Skywalker" OFF)
 OPTION(TCHEM_ATM_ENABLE_KOKKOSKERNELS "Flag to enable Kokkos-kernels" OFF)
+OPTION(TCHEM_ATM_ENABLE_COVERAGE  "Enable code coverage instrumentation" OFF)
 
 OPTION(KOKKOS_INSTALL_PATH "Path to Kokkos installation")
 OPTION(TINES_INSTALL_PATH "Path to Tines installation")
@@ -165,6 +166,27 @@ IF (SKYWALKER_INSTALL_PATH)
 
 ENDIF()
 ENDIF()
+
+
+# Code coverage
+
+if (TCHEM_ATM_ENABLE_COVERAGE)
+  MESSAGE(STATUS "Enabling code coverage instrumentation")
+  FIND_PROGRAM(LCOV_EXE lcov DOC "Lcov code coverage tool")
+  if (LCOV_EXE MATCHES "NOTFOUND")
+    MESSAGE(FATAL_ERROR "Could not find lcov for code coverage reporting!")
+  endif()
+
+  # Add code coverage compiler/linker flags
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+  SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+
+  # Add a "make coverage" target.
+  add_custom_target(coverage ${LCOV_EXE} --capture --directory . -o unfiltered_coverage.info
+    COMMAND ${LCOV_EXE} --remove unfiltered_coverage.info -o coverage.info '*/external/*' '*/tests/*' '*/validation/*'
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    COMMENT "Generating coverage report (coverage.info)")
+endif()
 
 
 #


### PR DESCRIPTION
Following the implementation of code coverage in [mam4xx](https://github.com/eagles-project/mam4xx), I am integrating this tool into TChem-atm. The final steps required to enable this tool in the TChem repository are detailed here:

[Codecov Quick Start Guide](https://docs.codecov.com/docs/quick-start)

The first step, Step 1: Sign up for Codecov, must be completed by either @nriemer  or @mwest1066 , as they have administrative access to the PCLAeroParams organization.

Once Step 1 is completed, I will proceed with the remaining steps.