### PR TITLE
Switch kokkos kernels submodule to use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/LLNL/sundials.git
 [submodule "external/kokkos-kernels"]
 	path = external/kokkos-kernels
-	url = git@github.com:odiazib/kokkos-kernels.git
+	url = https://github.com/odiazib/kokkos-kernels.git


### PR DESCRIPTION
Branch to see if we can get around the Dockerfile problems where it can not access kokkos kernels using ssh.

This resulted from (https://github.com/compdyn/partmc/actions/runs/11423259749/job/31782241106)

```
13.38 fatal: clone of 'git@github.com:odiazib/kokkos-kernels.git' into submodule path '/tchem_dir/external/kokkos-kernels' failed
13.38 Failed to clone 'external/kokkos-kernels'. Retry scheduled
13.38 Cloning into '/tchem_dir/external/kokkos-kernels'...
13.62 Host key verification failed.
13.62 fatal: Could not read from remote repository.
13.62 
13.62 Please make sure you have the correct access rights
13.62 and the repository exists.
13.62 fatal: clone of 'git@github.com:odiazib/kokkos-kernels.git' into submodule path '/tchem_dir/external/kokkos-kernels' failed
13.62 Failed to clone 'external/kokkos-kernels' a second time, aborting
```