### PR TITLE
Add aerosol support for host model (PartMC) to couple to TChem 

### DIFF
--- a/src/core/TChem_AerosolModelData.cpp
+++ b/src/core/TChem_AerosolModelData.cpp
@@ -85,7 +85,7 @@ int AerosolModelData::initChem(YAML::Node &root,
     // given the name of species return the YAML::NODE
     std::map<std::string, YAML::Node> gas_sp_info;
     // 2. get molecular weitghs and density of aerosol_species
-    std::vector<real_type> mw_aerosol_sp, density_aero_sp;
+    std::vector<real_type> mw_aerosol_sp, density_aero_sp, kappa_aero_sp;
     int i_aero_sp=0;
     // loops over species, only make map from aerosol species.
     // we assume that map of gas species was previously created in kmd.
@@ -104,6 +104,7 @@ int AerosolModelData::initChem(YAML::Node &root,
             //  std::cout <<"molecular weight" << item["molecular weight [kg mol-1]"]<<"\n";
              mw_aerosol_sp.push_back(item["molecular weight [kg mol-1]"].as<real_type>());
              density_aero_sp.push_back(item["density [kg m-3]"].as<real_type>());
+             kappa_aero_sp.push_back(item["kappa"].as<real_type>())
            }
         } else
         {
@@ -208,10 +209,13 @@ int AerosolModelData::initChem(YAML::Node &root,
     auto molecular_weights_host = molecular_weights_.view_host();
     aerosol_density_= real_type_1d_dual_view(do_not_init_tag("AMD::aerosol_density_"), nSpec_);
     auto aerosol_density_host = aerosol_density_.view_host();
+    aerosol_kappa_ = real_type_1d_dual_view(do_not_init_tag("AMD::kappa"), nSpec_);
+    auto aerosol_kappa_host = aero_kappa_.view_host();
     for (int i = 0; i < nSpec_; i++)
     {
       molecular_weights_host(i) = mw_aerosol_sp[i];
       aerosol_density_host(i) = density_aero_sp[i];
+      aerosol_kappa_host(i) = kappa_aero_sp[i];
     }
 
     molecular_weights_.modify_host();

--- a/src/core/TChem_AerosolModelData.cpp
+++ b/src/core/TChem_AerosolModelData.cpp
@@ -104,7 +104,7 @@ int AerosolModelData::initChem(YAML::Node &root,
             //  std::cout <<"molecular weight" << item["molecular weight [kg mol-1]"]<<"\n";
              mw_aerosol_sp.push_back(item["molecular weight [kg mol-1]"].as<real_type>());
              density_aero_sp.push_back(item["density [kg m-3]"].as<real_type>());
-             kappa_aero_sp.push_back(item["kappa"].as<real_type>())
+             kappa_aero_sp.push_back(item["kappa"].as<real_type>());
            }
         } else
         {
@@ -210,7 +210,7 @@ int AerosolModelData::initChem(YAML::Node &root,
     aerosol_density_= real_type_1d_dual_view(do_not_init_tag("AMD::aerosol_density_"), nSpec_);
     auto aerosol_density_host = aerosol_density_.view_host();
     aerosol_kappa_ = real_type_1d_dual_view(do_not_init_tag("AMD::kappa"), nSpec_);
-    auto aerosol_kappa_host = aero_kappa_.view_host();
+    auto aerosol_kappa_host = aerosol_kappa_.view_host();
     for (int i = 0; i < nSpec_; i++)
     {
       molecular_weights_host(i) = mw_aerosol_sp[i];

--- a/src/core/TChem_AerosolModelData.hpp
+++ b/src/core/TChem_AerosolModelData.hpp
@@ -38,8 +38,8 @@ namespace TChem {
   ordinal_type nConstSpec_gas_;
   // number of particles
   ordinal_type nParticles_;
-  // aerosol molecular weights and density
-  real_type_1d_dual_view molecular_weights_, aerosol_density_;
+  // aerosol molecular weights, density and kappa
+  real_type_1d_dual_view molecular_weights_, aerosol_density_, aerosol_kappa_;
   simpol_phase_transfer_type_1d_dual_view simpol_params_;
   ordinal_type nSimpol_tran_;
 
@@ -91,6 +91,7 @@ namespace TChem {
 
     amcd_real_type_1d_view molecular_weights;
     amcd_real_type_1d_view aerosol_density;
+    amcd_real_type_1d_view aerosol_kappa;
 
    };
 
@@ -104,6 +105,7 @@ namespace TChem {
     data.nSimpol_tran=amd.nSimpol_tran_;
     data.molecular_weights = amd.molecular_weights_.template view<SpT>();
     data.aerosol_density = amd.aerosol_density_.template view<SpT>();
+    data.aerosol_kappa = amd.aerosol_kappa_.template view<SpT>();
     data.simpol_params = amd.simpol_params_.template view<SpT>();
   return data;
   }

--- a/src/core/TChem_Driver.cpp
+++ b/src/core/TChem_Driver.cpp
@@ -297,6 +297,14 @@ ordinal_type TChem::Driver::getLengthOfStateVector() const {
   return Impl::getStateVectorSize(_kmcd_host.nSpec + _amcd_host.nSpec * _amcd_host.nParticles);
 }
 
+int TChem_getNumberConcentrationVectorSize() {
+  return g_tchem == nullptr ? -1 : g_tchem->getNumberConcentrationVectorSize();
+}
+
+ordinal_type TChem::Driver::getNumberConcentrationVectorSize() const{
+  return _amcd_host.nParticles;
+}
+
 /* Integrate a time step */
 void TChem_doTimestep(const double &del_t){
   g_tchem->doTimestep(del_t);

--- a/src/core/TChem_Driver.hpp
+++ b/src/core/TChem_Driver.hpp
@@ -1,5 +1,6 @@
 #include <TChem_KineticModelData.hpp>
 #include <TChem_KineticModelNCAR_ConstData.hpp>
+#include <TChem_AerosolModelData.hpp>
 #include <TChem_Util.hpp>
 
 namespace TChem {
@@ -11,7 +12,7 @@ public:
    using device_type = typename Tines::UseThisDevice<exec_space>::type;
 
    // Input files
-   std::string _chem_file, _therm_file;
+   std::string _chem_file, _aero_file;
 
    ordinal_type _team_size;
    ordinal_type _vector_size;
@@ -34,12 +35,25 @@ public:
    void createGasKineticModel(const std::string &chem_file);
    void createGasKineticModelConstData();
 
-   // Aerosols
-
    // Return number of gas species
    ordinal_type getNumberOfSpecies();
    // Return gas species name
    std::string getSpeciesName(int *index);
+
+   // Aerosol variables
+   TChem::AerosolModelData _amd;
+   TChem::AerosolModel_ConstData<host_device_type> _amcd_host;
+   TChem::AerosolModel_ConstData<device_type> _amcd_device;
+   void createAerosolModel(const std::string &aero_file);
+   void createAerosolModelConstData();
+
+   // Return number of aerosol species
+   ordinal_type getNumberOfAerosolSpecies();
+
+   // Return aerosol species information
+   real_type getAerosolSpeciesDensity(int *index);
+   real_type getAerosolSpeciesMW(int *index);
+   real_type getAerosolSpeciesKappa(int *index);
 
    // Integrate a single time step
    void doTimestep(const double del_t);
@@ -61,6 +75,7 @@ public:
    // Clean up
    void freeAll();
    void freeGasKineticModel();
+   void freeAerosolModel();
 
    // Diagnostics
 
@@ -80,3 +95,10 @@ extern "C" int TChem_getSpeciesName(int* index, char* result,
 extern "C" void TChem_doTimestep(const double &del_t);
 extern "C" int TChem_getStateVectorSize();
 extern "C" void TChem_getAllStateVectorHost(TChem::real_type *view);
+
+extern "C" TChem::ordinal_type TChem_getNumberOfAerosolSpecies();
+extern "C" int TChem_getAerosolSpeciesName(int* index, char* result,
+                                    const std::string::size_type buffer_size);
+extern "C" double TChem_getAerosolSpeciesDensity(int* index);
+extern "C" double TChem_getAerosolSpeciesMW(int* index);
+extern "C" double TChem_getAerosolSpeciesKappa(int* index);

--- a/src/core/TChem_Driver.hpp
+++ b/src/core/TChem_Driver.hpp
@@ -29,6 +29,7 @@ public:
    void setStateVector(double *array, const ordinal_type iBatch);
    void getStateVectorHost(real_type_2d_const_view_host &view);
 
+   ordinal_type getNumberConcentrationVectorSize() const;
    void setNumberConcentrationVector(double *array, const ordinal_type iBatch);
 
    // Gas variables
@@ -99,12 +100,13 @@ extern "C" int TChem_getSpeciesName(int* index, char* result,
                                     const std::string::size_type buffer_size);
 extern "C" void TChem_doTimestep(const double &del_t);
 extern "C" int TChem_getStateVectorSize();
+extern "C" int TChem_getNumberConcentrationVectorSize();
 extern "C" void TChem_getAllStateVectorHost(TChem::real_type *view);
-
 extern "C" TChem::ordinal_type TChem_getNumberOfAeroSpecies();
 extern "C" int TChem_getAerosolSpeciesName(int* index, char* result,
-                                    const std::string::size_type buffer_size);
+                                           const std::string::size_type buffer_size);
 extern "C" double TChem_getAerosolSpeciesDensity(int* index);
 extern "C" double TChem_getAerosolSpeciesMW(int* index);
 extern "C" double TChem_getAerosolSpeciesKappa(int* index);
-extern "C" void TChem_setNumberConcentrationVector(TChem::real_type *array, const TChem::ordinal_type iBatch);
+extern "C" void TChem_setNumberConcentrationVector(TChem::real_type *array,
+                                                   const TChem::ordinal_type iBatch);

--- a/src/core/TChem_Driver.hpp
+++ b/src/core/TChem_Driver.hpp
@@ -21,12 +21,15 @@ public:
    ordinal_type _nBatch;
    void setBatchSize(ordinal_type nBatch);
    real_type_2d_view_host _state;
+   real_type_2d_view_host _number_concentration;
    void createStateVector(ordinal_type nBatch);
    ordinal_type getLengthOfStateVector() const;
    auto getStateVectorSize();
    auto getStateVector(const ordinal_type iBatch);
    void setStateVector(double *array, const ordinal_type iBatch);
    void getStateVectorHost(real_type_2d_const_view_host &view);
+
+   void setNumberConcentrationVector(double *array, const ordinal_type iBatch);
 
    // Gas variables
    TChem::KineticModelData _kmd;
@@ -46,6 +49,7 @@ public:
    TChem::AerosolModel_ConstData<device_type> _amcd_device;
    void createAerosolModel(const std::string &aero_file);
    void createAerosolModelConstData();
+   void createNumberConcentrationVector(const ordinal_type iBatch);
 
    // Return number of aerosol species
    ordinal_type getNumberOfAeroSpecies();
@@ -103,3 +107,4 @@ extern "C" int TChem_getAerosolSpeciesName(int* index, char* result,
 extern "C" double TChem_getAerosolSpeciesDensity(int* index);
 extern "C" double TChem_getAerosolSpeciesMW(int* index);
 extern "C" double TChem_getAerosolSpeciesKappa(int* index);
+extern "C" void TChem_setNumberConcentrationVector(TChem::real_type *array, const TChem::ordinal_type iBatch);

--- a/src/core/TChem_Driver.hpp
+++ b/src/core/TChem_Driver.hpp
@@ -48,9 +48,10 @@ public:
    void createAerosolModelConstData();
 
    // Return number of aerosol species
-   ordinal_type getNumberOfAerosolSpecies();
+   ordinal_type getNumberOfAeroSpecies();
 
    // Return aerosol species information
+   std::string getAerosolSpeciesName(int *index); 
    real_type getAerosolSpeciesDensity(int *index);
    real_type getAerosolSpeciesMW(int *index);
    real_type getAerosolSpeciesKappa(int *index);
@@ -96,7 +97,7 @@ extern "C" void TChem_doTimestep(const double &del_t);
 extern "C" int TChem_getStateVectorSize();
 extern "C" void TChem_getAllStateVectorHost(TChem::real_type *view);
 
-extern "C" TChem::ordinal_type TChem_getNumberOfAerosolSpecies();
+extern "C" TChem::ordinal_type TChem_getNumberOfAeroSpecies();
 extern "C" int TChem_getAerosolSpeciesName(int* index, char* result,
                                     const std::string::size_type buffer_size);
 extern "C" double TChem_getAerosolSpeciesDensity(int* index);


### PR DESCRIPTION
- [x] Add kappa to TChem_AerosolModelData
- [x] Add AerosolModelConstData to TChem_Driver
- [x] Allocate state vector length to include aerosol species and particles and allocate number concentration array.
- [x] Add getters for aerosol related items:
  - [x] Aerosol species names
  - [x] Density
  - [x] Molecular weight
  - [x] Kappa
- [ ] Change to the correct code to call chemistry (Aerosol chemistry)
   - [ ] CVODE
- [x] Setter and getter for maximum number of particles