### PR TITLE
Add CAMP inputs files to CB05CL_AE5 example

### DIFF
--- a/src/examples/runs/atmospheric_chemistry/CB05CL_AE5/CAMP/cb05cl_ae5_abs_tol.json
+++ b/src/examples/runs/atmospheric_chemistry/CB05CL_AE5/CAMP/cb05cl_ae5_abs_tol.json
@@ -1,0 +1,407 @@
+{
+  "camp-data" : [
+    {
+      "type" : "RELATIVE_TOLERANCE",
+      "value" : 1.0E-04
+    },
+    {
+      "name" : "NO2",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "NO",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "O",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "O3",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "NO3",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "O1D",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "OH",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "HO2",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "N2O5",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "HNO3",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "HONO",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "PNA",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "H2O2",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "XO2",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "XO2N",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "NTR",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "ROOH",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "FORM",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "ALD2",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "ALDX",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "PAR",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "CO",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "MEO2",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "MEPX",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "MEOH",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "HCO3",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "FACD",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "C2O3",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "PAN",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "PACD",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "AACD",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "CXO3",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "PANX",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "ROR",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "OLE",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "ETH",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "IOLE",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "TOL",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "CRES",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "TO2",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "TOLRO2",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "OPEN",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "CRO",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "MGLY",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "XYL",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "XYLRO2",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "ISOP",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "ISPD",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "ISOPRXN",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "TERP",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "TRPRXN",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "SO2",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "SULF",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "SULRXN",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "ETOH",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "ETHA",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "CL2",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "CL",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "HOCL",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "CLO",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "FMCL",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "HCL",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "TOLNRXN",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "TOLHRXN",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "XYLNRXN",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "XYLHRXN",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "BENZENE",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "BENZRO2",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "BNZNRXN",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "BNZHRXN",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "SESQ",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "SESQRXN",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "M",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "O2",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "N2",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "H2O",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "CH4",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "H2",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    },
+    {
+      "name" : "N2O",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E-03
+    },
+    {
+      "name" : "DUMMY",
+      "type" : "CHEM_SPEC",
+      "absolute integration tolerance" : 1.0E+00
+    }
+]}

--- a/src/examples/runs/atmospheric_chemistry/CB05CL_AE5/CAMP/cb05cl_ae5_init.json
+++ b/src/examples/runs/atmospheric_chemistry/CB05CL_AE5/CAMP/cb05cl_ae5_init.json
@@ -1,0 +1,409 @@
+{ "camp-data" : [
+  {
+    "name" : "AACD",
+    "type" : "CHEM_SPEC",
+    "init conc" : 1.0E-03
+  },
+  {
+    "name" : "ALD2",
+    "type" : "CHEM_SPEC",
+    "init conc" : 5.0E-03
+  },
+  {
+    "name" : "ALDX",
+    "type" : "CHEM_SPEC",
+    "init conc" : 1.0E-03
+  },
+  {
+    "name" : "BENZENE",
+    "type" : "CHEM_SPEC",
+    "init conc" : 1.0E-03
+  },
+  {
+    "name" : "BENZRO2",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "BNZHRXN",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "BNZNRXN",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "C2O3",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "CH4",
+    "type" : "CHEM_SPEC",
+    "init conc" : 1.85,
+    "tracer type" : "CONSTANT"
+  },
+  {
+    "name" : "CL",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "CL2",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.02
+  },
+  {
+    "name" : "CLO",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "CO",
+    "type" : "CHEM_SPEC",
+    "init conc" : 20.0
+  },
+  {
+    "name" : "CRES",
+    "type" : "CHEM_SPEC",
+    "init conc" : 5.0E-06
+  },
+  {
+    "name" : "CRO",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "CXO3",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "ETH",
+    "type" : "CHEM_SPEC",
+    "init conc" : 10.0E-03
+  },
+  {
+    "name" : "ETHA",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.5E-03
+  },
+  {
+    "name" : "ETOH",
+    "type" : "CHEM_SPEC",
+    "init conc" : 100.0E-03
+  },
+  {
+    "name" : "FACD",
+    "type" : "CHEM_SPEC",
+    "init conc" : 1.0
+  },
+  {
+    "name" : "FMCL",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "FORM",
+    "type" : "CHEM_SPEC",
+    "init conc" : 15.0E-03
+  },
+  {
+    "name" : "H2O2",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.08E-03
+  },
+  {
+    "name" : "HCL",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0,
+    "orig init" : 1.0E-03
+  },
+  {
+    "name" : "HCO3",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "HNO3",
+    "type" : "CHEM_SPEC",
+    "init conc" : 2.0E-03
+  },
+  {
+    "name" : "HO2",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.1E-03
+  },
+  {
+    "name" : "HOCL",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "HONO",
+    "type" : "CHEM_SPEC",
+    "init conc" : 1.0E-03
+  },
+  {
+    "name" : "IOLE",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.5E-03
+  },
+  {
+    "name" : "ISOP",
+    "type" : "CHEM_SPEC",
+    "init conc" : 1.0E-03
+  },
+  {
+    "name" : "ISOPRXN",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "ISPD",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "MEO2",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "MEOH",
+    "type" : "CHEM_SPEC",
+    "init conc" : 2.0E-03
+  },
+  {
+    "name" : "MEPX",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "MGLY",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "N2O5",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "NO",
+    "type" : "CHEM_SPEC",
+    "init conc" : 2.0E-03
+  },
+  {
+    "name" : "NO2",
+    "type" : "CHEM_SPEC",
+    "init conc" : 18.0E-03
+  },
+  {
+    "name" : "NO3",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "NTR",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "O",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "O1D",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "O3",
+    "type" : "CHEM_SPEC",
+    "init conc" : 60.0E-03
+  },
+  {
+    "name" : "OH",
+    "type" : "CHEM_SPEC",
+    "init conc" : 1.0E-6
+  },
+  {
+    "name" : "OLE",
+    "type" : "CHEM_SPEC",
+    "init conc" : 3.0E-03
+  },
+  {
+    "name" : "OPEN",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "PACD",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "PAN",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "PANX",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "PAR",
+    "type" : "CHEM_SPEC",
+    "init conc" : 1.0E-03
+  },
+  {
+    "name" : "PNA",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "ROOH",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "ROR",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "SESQ",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.1E-03
+  },
+  {
+    "name" : "SESQRXN",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "SO2",
+    "type" : "CHEM_SPEC",
+    "init conc" : 4.0E-03
+  },
+  {
+    "name" : "SULF",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "SULRXN",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "TERP",
+    "type" : "CHEM_SPEC",
+    "init conc" : 40.0E-03
+  },
+  {
+    "name" : "TO2",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "TOL",
+    "type" : "CHEM_SPEC",
+    "init conc" : 8.3E-03
+  },
+  {
+    "name" : "TOLHRXN",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "TOLNRXN",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "TOLRO2",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "TRPRXN",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "XO2",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "XO2N",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "XYL",
+    "type" : "CHEM_SPEC",
+    "init conc" : 3.0E-03
+  },
+  {
+    "name" : "XYLHRXN",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "XYLNRXN",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "XYLRO2",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "N2O",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.3
+  },
+  {
+    "name" : "DUMMY",
+    "type" : "CHEM_SPEC",
+    "init conc" : 0.0
+  },
+  {
+    "name" : "O2",
+    "type" : "CHEM_SPEC",
+    "init conc" : 2.095E05,
+    "tracer type" : "CONSTANT"
+  },
+  {
+    "name" : "H2O",
+    "type" : "CHEM_SPEC",
+    "init conc" : 1.0E03,
+    "tracer type" : "CONSTANT"
+  },
+  {
+    "name" : "H2",
+    "type" : "CHEM_SPEC",
+    "init conc" : 5.6E-01,
+    "tracer type" : "CONSTANT"
+  },
+  {
+    "name" : "M",
+    "type" : "CHEM_SPEC",
+    "init conc" : 1.0E06,
+    "tracer type" : "CONSTANT"
+  },
+  {
+    "name" : "N2",
+    "type" : "CHEM_SPEC",
+    "init conc" : 7.808E05,
+    "tracer type" : "CONSTANT"
+  }
+]}

--- a/src/examples/runs/atmospheric_chemistry/CB05CL_AE5/CAMP/cb05cl_ae5_mechanism.json
+++ b/src/examples/runs/atmospheric_chemistry/CB05CL_AE5/CAMP/cb05cl_ae5_mechanism.json
@@ -1,0 +1,3103 @@
+{ "camp-data" : [
+  {
+    "name" : "cb05cl_ae5",
+    "type" : "MECHANISM",
+    "reactions" : [
+      {
+        "rxn id" : "R1",
+        "reactants" : {
+          "NO2" : {}
+        },
+        "products" : {
+          "NO" : {} ,
+          "O" : {}
+        },
+        "orig params" : "TUV_J(4, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R2",
+        "reactants" : {
+          "O" : {} ,
+          "O2" : {} ,
+          "M" : {}
+        },
+        "products" : {
+          "O3" : {} ,
+          "M" : {}
+        },
+        "orig params" : "O2 * M * CMAQ_1to4(6.0E-34, -2.4, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 6.0E-34,
+        "B" : -2.4,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R3",
+        "reactants" : {
+          "O3" : {} ,
+          "NO" : {}
+        },
+        "products" : {
+          "NO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(3.0E-12, 0.0E+00, 1500.0)",
+        "type" : "ARRHENIUS",
+        "A" : 3.0E-12,
+        "B" : 0.0E+00,
+        "C" : -1500.0
+      },
+      {
+        "rxn id" : "R4",
+        "reactants" : {
+          "O" : {} ,
+          "NO2" : {}
+        },
+        "products" : {
+          "NO" : {}
+        },
+        "orig params" : "CMAQ_1to4(5.6E-12, 0.0E+00, -180.0)",
+        "type" : "ARRHENIUS",
+        "A" : 5.6E-12,
+        "B" : 0.0E+00,
+        "C" : 180.0
+      },
+      {
+        "rxn id" : "R5",
+        "reactants" : {
+          "O" : {} ,
+          "NO2" : {}
+        },
+        "products" : {
+          "NO3" : {}
+        },
+        "orig params" : "CMAQ_10(2.5E-31, -1.8, 0.0E+00, 2.2E-11, -0.7, 0.0E+00, 0.6, 1.0)",
+        "type" : "TROE",
+        "k0_A" : 2.5E-31,
+        "k0_B" : -1.8,
+        "k0_C" : -0.0E+00,
+        "kinf_A" : 2.2E-11,
+        "kinf_B" : -0.7,
+        "kinf_C" : -0.0E+00,
+        "Fc" : 0.6,
+        "N" : 1.0
+      },
+      {
+        "rxn id" : "R6",
+        "reactants" : {
+          "O" : {} ,
+          "NO" : {}
+        },
+        "products" : {
+          "NO2" : {}
+        },
+        "orig params" : "CMAQ_10(9.0E-32, -1.5, 0.0E+00, 3.0E-11, 0.0E+00, 0.0E+00, 0.6, 1.0)",
+        "type" : "TROE",
+        "k0_A" : 9.0E-32,
+        "k0_B" : -1.5,
+        "k0_C" : -0.0E+00,
+        "kinf_A" : 3.0E-11,
+        "kinf_B" : 0.0E+00,
+        "kinf_C" : -0.0E+00,
+        "Fc" : 0.6,
+        "N" : 1.0
+      },
+      {
+        "rxn id" : "R7",
+        "reactants" : {
+          "NO2" : {} ,
+          "O3" : {}
+        },
+        "products" : {
+          "NO3" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.2E-13, 0.0E+00, 2450.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.2E-13,
+        "B" : 0.0E+00,
+        "C" : -2450.0
+      },
+      {
+        "rxn id" : "R8",
+        "reactants" : {
+          "O3" : {}
+        },
+        "products" : {
+          "O" : {}
+        },
+        "orig params" : "TUV_J(3, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R9",
+        "reactants" : {
+          "O3" : {}
+        },
+        "products" : {
+          "O1D" : {}
+        },
+        "orig params" : "TUV_J(2, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R10",
+        "reactants" : {
+          "O1D" : {} ,
+          "M" : {}
+        },
+        "products" : {
+          "O" : {} ,
+          "M" : {}
+        },
+        "orig params" : "M * CMAQ_1to4(2.1E-11, 0.0E+00, -102.0)",
+        "type" : "ARRHENIUS",
+        "A" : 2.1E-11,
+        "B" : 0.0E+00,
+        "C" : 102.0
+      },
+      {
+        "rxn id" : "R11",
+        "reactants" : {
+          "O1D" : {} ,
+          "H2O" : {}
+        },
+        "products" : {
+          "OH" : { "yield" : 2.000 }
+        },
+        "orig params" : "H2O * CMAQ_1to4(2.2E-10, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 2.2E-10,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R12",
+        "reactants" : {
+          "O3" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "HO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.7E-12, 0.0E+00, 940.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.7E-12,
+        "B" : 0.0E+00,
+        "C" : -940.0
+      },
+      {
+        "rxn id" : "R13",
+        "reactants" : {
+          "O3" : {} ,
+          "HO2" : {}
+        },
+        "products" : {
+          "OH" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.0E-14, 0.0E+00, 490.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.0E-14,
+        "B" : 0.0E+00,
+        "C" : -490.0
+      },
+      {
+        "rxn id" : "R14",
+        "reactants" : {
+          "NO3" : {}
+        },
+        "products" : {
+          "NO2" : {} ,
+          "O" : {}
+        },
+        "orig params" : "TUV_J(6, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R15",
+        "reactants" : {
+          "NO3" : {}
+        },
+        "products" : {
+          "NO" : {}
+        },
+        "orig params" : "TUV_J(5, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R16",
+        "reactants" : {
+          "NO3" : {} ,
+          "NO" : {}
+        },
+        "products" : {
+          "NO2" : { "yield" : 2.000 }
+        },
+        "orig params" : "CMAQ_1to4(1.5E-11, 0.0E+00, -170.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.5E-11,
+        "B" : 0.0E+00,
+        "C" : 170.0
+      },
+      {
+        "rxn id" : "R17",
+        "reactants" : {
+          "NO3" : {} ,
+          "NO2" : {}
+        },
+        "products" : {
+          "NO" : {} ,
+          "NO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(4.5E-14, 0.0E+00, 1260.0)",
+        "type" : "ARRHENIUS",
+        "A" : 4.5E-14,
+        "B" : 0.0E+00,
+        "C" : -1260.0
+      },
+      {
+        "rxn id" : "R18",
+        "reactants" : {
+          "NO3" : {} ,
+          "NO2" : {}
+        },
+        "products" : {
+          "N2O5" : {}
+        },
+        "orig params" : "CMAQ_10(2.0E-30, -4.4, 0.0E+00, 1.4E-12, -0.7, 0.0E+00, 0.6, 1.0)",
+        "type" : "TROE",
+        "k0_A" : 2.0E-30,
+        "k0_B" : -4.4,
+        "k0_C" : -0.0E+00,
+        "kinf_A" : 1.4E-12,
+        "kinf_B" : -0.7,
+        "kinf_C" : -0.0E+00,
+        "Fc" : 0.6,
+        "N" : 1.0
+      },
+      {
+        "rxn id" : "R19",
+        "reactants" : {
+          "N2O5" : {} ,
+          "H2O" : {}
+        },
+        "products" : {
+          "HNO3" : { "yield" : 2.000 } ,
+          "DUMMY" : {}
+        },
+        "orig params" : "H2O * CMAQ_1to4(2.5E-22, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 2.5E-22,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R20",
+        "reactants" : {
+          "N2O5" : {} ,
+          "H2O" : { "qty" : 2 }
+        },
+        "products" : {
+          "HNO3" : { "yield" : 2.000 }
+        },
+        "orig params" : "H2O**2 * CMAQ_1to4(1.8E-39, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 1.8E-39,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R21",
+        "reactants" : {
+          "N2O5" : {}
+        },
+        "products" : {
+          "NO3" : {} ,
+          "NO2" : {} ,
+          "DUMMY" : {}
+        },
+        "orig params" : "CMAQ_10(1.0E-03, -3.5, 11000.0, 9.7E+14, 0.1, 11080.0, 0.45, 1.0)",
+        "type" : "TROE",
+        "k0_A" : 1.0E-03,
+        "k0_B" : -3.5,
+        "k0_C" : -11000.0,
+        "kinf_A" : 9.7E+14,
+        "kinf_B" : 0.1,
+        "kinf_C" : -11080.0,
+        "Fc" : 0.45,
+        "N" : 1.0
+      },
+      {
+        "rxn id" : "R22",
+        "reactants" : {
+          "NO" : { "qty" : 2 } ,
+          "O2" : {}
+        },
+        "products" : {
+          "NO2" : { "yield" : 2.000 }
+        },
+        "orig params" : "O2 * CMAQ_1to4(3.3E-39, 0.0E+00, -530.0)",
+        "type" : "ARRHENIUS",
+        "A" : 3.3E-39,
+        "B" : 0.0E+00,
+        "C" : 530.0
+      },
+      {
+        "rxn id" : "R23",
+        "reactants" : {
+          "NO" : {} ,
+          "NO2" : {} ,
+          "H2O" : {}
+        },
+        "products" : {
+          "HONO" : { "yield" : 2.000 }
+        },
+        "orig params" : "H2O * CMAQ_1to4(5.0E-40, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 5.0E-40,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R24",
+        "reactants" : {
+          "NO" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "HONO" : {}
+        },
+        "orig params" : "CMAQ_10(7.0E-31, -2.6, 0.0E+00, 3.6E-11, -0.1, 0.0E+00, 0.6, 1.0)",
+        "type" : "TROE",
+        "k0_A" : 7.0E-31,
+        "k0_B" : -2.6,
+        "k0_C" : -0.0E+00,
+        "kinf_A" : 3.6E-11,
+        "kinf_B" : -0.1,
+        "kinf_C" : -0.0E+00,
+        "Fc" : 0.6,
+        "N" : 1.0
+      },
+      {
+        "rxn id" : "R25",
+        "reactants" : {
+          "HONO" : {}
+        },
+        "products" : {
+          "NO" : {} ,
+          "OH" : {}
+        },
+        "orig params" : "TUV_J(12, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R26",
+        "reactants" : {
+          "OH" : {} ,
+          "HONO" : {}
+        },
+        "products" : {
+          "NO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.8E-11, 0.0E+00, 390.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.8E-11,
+        "B" : 0.0E+00,
+        "C" : -390.0
+      },
+      {
+        "rxn id" : "R27",
+        "reactants" : {
+          "HONO" : { "qty" : 2 }
+        },
+        "products" : {
+          "NO" : {} ,
+          "NO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.0E-20, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 1.0E-20,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R28",
+        "reactants" : {
+          "NO2" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "HNO3" : {}
+        },
+        "orig params" : "CMAQ_10(2.0E-30, -3.0, 0.0E+00, 2.5E-11, 0.0E+00, 0.0E+00, 0.6, 1.0)",
+        "type" : "TROE",
+        "k0_A" : 2.0E-30,
+        "k0_B" : -3.0,
+        "k0_C" : -0.0E+00,
+        "kinf_A" : 2.5E-11,
+        "kinf_B" : 0.0E+00,
+        "kinf_C" : -0.0E+00,
+        "Fc" : 0.6,
+        "N" : 1.0
+      },
+      {
+        "rxn id" : "R29",
+        "reactants" : {
+          "OH" : {} ,
+          "HNO3" : {}
+        },
+        "products" : {
+          "NO3" : {}
+        },
+        "orig params" : "CMAQ_8(2.4E-14, -460.0, 2.7E-17, -2199.0, 6.5E-34, -1335.0)",
+        "type" : "CMAQ_OH_HNO3",
+        "k0_A" : 2.4E-14,
+        "k0_C" : 460.0,
+        "k2_A" : 2.7E-17,
+        "k2_C" : 2199.0,
+        "k3_A" : 6.5E-34,
+        "k3_C" : 1335.0
+      },
+      {
+        "rxn id" : "R30",
+        "reactants" : {
+          "HO2" : {} ,
+          "NO" : {}
+        },
+        "products" : {
+          "OH" : {} ,
+          "NO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(3.5E-12, 0.0E+00, -250.0)",
+        "type" : "ARRHENIUS",
+        "A" : 3.5E-12,
+        "B" : 0.0E+00,
+        "C" : 250.0
+      },
+      {
+        "rxn id" : "R31",
+        "reactants" : {
+          "HO2" : {} ,
+          "NO2" : {}
+        },
+        "products" : {
+          "PNA" : {}
+        },
+        "orig params" : "CMAQ_10(1.8E-31, -3.2, 0.0E+00, 4.7E-12, 0.0E+00, 0.0E+00, 0.6, 1.0)",
+        "type" : "TROE",
+        "k0_A" : 1.8E-31,
+        "k0_B" : -3.2,
+        "k0_C" : -0.0E+00,
+        "kinf_A" : 4.7E-12,
+        "kinf_B" : 0.0E+00,
+        "kinf_C" : -0.0E+00,
+        "Fc" : 0.6,
+        "N" : 1.0
+      },
+      {
+        "rxn id" : "R32",
+        "reactants" : {
+          "PNA" : {}
+        },
+        "products" : {
+          "HO2" : {} ,
+          "NO2" : {}
+        },
+        "orig params" : "CMAQ_10(4.1E-5, 0.0E+00, 10650.0, 4.8E15, 0.0E+00, 11170.0, 0.6, 1.0)",
+        "type" : "TROE",
+        "k0_A" : 4.1E-5,
+        "k0_B" : 0.0E+00,
+        "k0_C" : -10650.0,
+        "kinf_A" : 4.8E15,
+        "kinf_B" : 0.0E+00,
+        "kinf_C" : -11170.0,
+        "Fc" : 0.6,
+        "N" : 1.0
+      },
+      {
+        "rxn id" : "R33",
+        "reactants" : {
+          "OH" : {} ,
+          "PNA" : {}
+        },
+        "products" : {
+          "NO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.3E-12, 0.0E+00, -380.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.3E-12,
+        "B" : 0.0E+00,
+        "C" : 380.0
+      },
+      {
+        "rxn id" : "R34",
+        "reactants" : {
+          "HO2" : { "qty" : 2 }
+        },
+        "products" : {
+          "H2O2" : {} ,
+          "DUMMY" : {}
+        },
+        "orig params" : "CMAQ_9(2.3E-13, -6.0E+02, 1.7E-33, -1.0E+03)",
+        "type" : "CMAQ_H2O2",
+        "k1_A" : 2.3E-13,
+        "k1_C" : 6.0E+02,
+        "k2_A" : 1.7E-33,
+        "k2_C" : 1.0E+03
+      },
+      {
+        "rxn id" : "R35",
+        "reactants" : {
+          "HO2" : { "qty" : 2 } ,
+          "H2O" : {}
+        },
+        "products" : {
+          "H2O2" : {}
+        },
+        "orig params" : "H2O * CMAQ_9(3.22E-34, -2.8E+03, 2.38E-54, -3.2E+3)",
+        "type" : "CMAQ_H2O2",
+        "k1_A" : 3.22E-34,
+        "k1_C" : 2.8E+03,
+        "k2_A" : 2.38E-54,
+        "k2_C" : 3.2E+3
+      },
+      {
+        "rxn id" : "R36",
+        "reactants" : {
+          "H2O2" : {}
+        },
+        "products" : {
+          "OH" : { "yield" : 2.000 }
+        },
+        "orig params" : "TUV_J(11, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R37",
+        "reactants" : {
+          "OH" : {} ,
+          "H2O2" : {}
+        },
+        "products" : {
+          "HO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(2.9E-12, 0.0E+00, 160.0)",
+        "type" : "ARRHENIUS",
+        "A" : 2.9E-12,
+        "B" : 0.0E+00,
+        "C" : -160.0
+      },
+      {
+        "rxn id" : "R38",
+        "reactants" : {
+          "O1D" : {} ,
+          "H2" : {}
+        },
+        "products" : {
+          "OH" : {} ,
+          "HO2" : {}
+        },
+        "orig params" : "H2 * CMAQ_1to4(1.1E-10, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 1.1E-10,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R39",
+        "reactants" : {
+          "OH" : {} ,
+          "H2" : {}
+        },
+        "products" : {
+          "HO2" : {}
+        },
+        "orig params" : "H2 * CMAQ_1to4(5.5E-12, 0.0E+00, 2000.0) {IUPAC '06 at 230K evaluates 9/10 * this}",
+        "type" : "ARRHENIUS",
+        "A" : 5.5E-12,
+        "B" : 0.0E+00,
+        "C" : -2000.0
+      },
+      {
+        "rxn id" : "R40",
+        "reactants" : {
+          "OH" : {} ,
+          "O" : {}
+        },
+        "products" : {
+          "HO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(2.2E-11, 0.0E+00, -120.0)",
+        "type" : "ARRHENIUS",
+        "A" : 2.2E-11,
+        "B" : 0.0E+00,
+        "C" : 120.0
+      },
+      {
+        "rxn id" : "R41",
+        "reactants" : {
+          "OH" : { "qty" : 2 }
+        },
+        "products" : {
+          "O" : {}
+        },
+        "orig params" : "CMAQ_1to4(4.2E-12, 0.0E+00, 240.0) {IUPAC '06 at 230K evaluates 4/3* this}",
+        "type" : "ARRHENIUS",
+        "A" : 4.2E-12,
+        "B" : 0.0E+00,
+        "C" : -240.0
+      },
+      {
+        "rxn id" : "R42",
+        "reactants" : {
+          "OH" : { "qty" : 2 }
+        },
+        "products" : {
+          "H2O2" : {}
+        },
+        "orig params" : "CMAQ_10(6.9E-31, -1.0, 0.0E+00, 2.6E-11, 0.0E+00, 0.0E+00, 0.6, 1.0)",
+        "type" : "TROE",
+        "k0_A" : 6.9E-31,
+        "k0_B" : -1.0,
+        "k0_C" : -0.0E+00,
+        "kinf_A" : 2.6E-11,
+        "kinf_B" : 0.0E+00,
+        "kinf_C" : -0.0E+00,
+        "Fc" : 0.6,
+        "N" : 1.0
+      },
+      {
+        "rxn id" : "R43",
+        "reactants" : {
+          "OH" : {} ,
+          "HO2" : {}
+        },
+        "products" : {
+          "DUMMY" : {}
+        },
+        "orig params" : "CMAQ_1to4(4.8E-11, 0.0E+00, -250.0)",
+        "type" : "ARRHENIUS",
+        "A" : 4.8E-11,
+        "B" : 0.0E+00,
+        "C" : 250.0
+      },
+      {
+        "rxn id" : "R44",
+        "reactants" : {
+          "HO2" : {} ,
+          "O" : {}
+        },
+        "products" : {
+          "OH" : {}
+        },
+        "orig params" : "CMAQ_1to4(3.0E-11, 0.0E+00, -200.0)",
+        "type" : "ARRHENIUS",
+        "A" : 3.0E-11,
+        "B" : 0.0E+00,
+        "C" : 200.0
+      },
+      {
+        "rxn id" : "R45",
+        "reactants" : {
+          "H2O2" : {} ,
+          "O" : {}
+        },
+        "products" : {
+          "OH" : {} ,
+          "HO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.4E-12, 0.0E+00, 2000.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.4E-12,
+        "B" : 0.0E+00,
+        "C" : -2000.0
+      },
+      {
+        "rxn id" : "R46",
+        "reactants" : {
+          "NO3" : {} ,
+          "O" : {}
+        },
+        "products" : {
+          "NO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.0E-11, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 1.0E-11,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R47",
+        "reactants" : {
+          "NO3" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "HO2" : {} ,
+          "NO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(2.2E-11, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 2.2E-11,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R48",
+        "reactants" : {
+          "NO3" : {} ,
+          "HO2" : {}
+        },
+        "products" : {
+          "HNO3" : {}
+        },
+        "orig params" : "CMAQ_1to4(3.5E-12, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 3.5E-12,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R49",
+        "reactants" : {
+          "NO3" : {} ,
+          "O3" : {}
+        },
+        "products" : {
+          "NO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.0E-17, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 1.0E-17,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R50",
+        "reactants" : {
+          "NO3" : { "qty" : 2 }
+        },
+        "products" : {
+          "NO2" : { "yield" : 2.000 }
+        },
+        "orig params" : "CMAQ_1to4(8.5E-13, 0.0E+00, 2450.0)",
+        "type" : "ARRHENIUS",
+        "A" : 8.5E-13,
+        "B" : 0.0E+00,
+        "C" : -2450.0
+      },
+      {
+        "rxn id" : "R51",
+        "reactants" : {
+          "PNA" : {}
+        },
+        "products" : {
+          "HO2" : { "yield" : 0.610 } ,
+          "NO2" : { "yield" : 0.610 } ,
+          "OH" : { "yield" : 0.390 } ,
+          "NO3" : { "yield" : 0.390 }
+        },
+        "orig params" : "TUV_J(14, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R52",
+        "reactants" : {
+          "HNO3" : {}
+        },
+        "products" : {
+          "OH" : {} ,
+          "NO2" : {}
+        },
+        "orig params" : "TUV_J(13, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R53",
+        "reactants" : {
+          "N2O5" : {}
+        },
+        "products" : {
+          "NO2" : {} ,
+          "NO3" : {}
+        },
+        "orig params" : "TUV_J(8, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R54",
+        "reactants" : {
+          "XO2" : {} ,
+          "NO" : {}
+        },
+        "products" : {
+          "NO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(2.6E-12, 0.0E+00, -365.0)",
+        "type" : "ARRHENIUS",
+        "A" : 2.6E-12,
+        "B" : 0.0E+00,
+        "C" : 365.0
+      },
+      {
+        "rxn id" : "R55",
+        "reactants" : {
+          "XO2N" : {} ,
+          "NO" : {}
+        },
+        "products" : {
+          "NTR" : {}
+        },
+        "orig params" : "CMAQ_1to4(2.6E-12, 0.0E+00, -365.0)",
+        "type" : "ARRHENIUS",
+        "A" : 2.6E-12,
+        "B" : 0.0E+00,
+        "C" : 365.0
+      },
+      {
+        "rxn id" : "R56",
+        "reactants" : {
+          "XO2" : {} ,
+          "HO2" : {}
+        },
+        "products" : {
+          "ROOH" : {}
+        },
+        "orig params" : "CMAQ_1to4(7.5E-13, 0.0E+00, -700.0)",
+        "type" : "ARRHENIUS",
+        "A" : 7.5E-13,
+        "B" : 0.0E+00,
+        "C" : 700.0
+      },
+      {
+        "rxn id" : "R57",
+        "reactants" : {
+          "XO2N" : {} ,
+          "HO2" : {}
+        },
+        "products" : {
+          "ROOH" : {}
+        },
+        "orig params" : "CMAQ_1to4(7.5E-13, 0.0E+00, -700.0)",
+        "type" : "ARRHENIUS",
+        "A" : 7.5E-13,
+        "B" : 0.0E+00,
+        "C" : 700.0
+      },
+      {
+        "rxn id" : "R58",
+        "reactants" : {
+          "XO2" : { "qty" : 2 }
+        },
+        "products" : {
+          "DUMMY" : {}
+        },
+        "orig params" : "CMAQ_1to4(6.8E-14, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 6.8E-14,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R59",
+        "reactants" : {
+          "XO2N" : { "qty" : 2 }
+        },
+        "products" : {
+          "DUMMY" : {}
+        },
+        "orig params" : "CMAQ_1to4(6.8E-14, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 6.8E-14,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R60",
+        "reactants" : {
+          "XO2" : {} ,
+          "XO2N" : {}
+        },
+        "products" : {
+          "DUMMY" : {}
+        },
+        "orig params" : "CMAQ_1to4(6.8E-14, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 6.8E-14,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R61",
+        "reactants" : {
+          "NTR" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "HNO3" : {} ,
+          "HO2" : {} ,
+          "FORM" : { "yield" : 0.330 } ,
+          "ALD2" : { "yield" : 0.330 } ,
+          "ALDX" : { "yield" : 0.330 } ,
+          "PAR" : { "yield" : -0.660 }
+        },
+        "orig params" : "CMAQ_1to4(5.9E-13, 0.0E+00, 360.0)",
+        "type" : "ARRHENIUS",
+        "A" : 5.9E-13,
+        "B" : 0.0E+00,
+        "C" : -360.0
+      },
+      {
+        "rxn id" : "R62",
+        "reactants" : {
+          "NTR" : {}
+        },
+        "products" : {
+          "NO2" : {} ,
+          "HO2" : {},
+          "FORM" : { "yield" : 0.330 } ,
+          "ALD2" : { "yield" : 0.330 } ,
+          "ALDX" : { "yield" : 0.330 } ,
+          "PAR" : { "yield" : -0.660 }
+        },
+        "orig params" : "TUV_J(91, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R63",
+        "reactants" : {
+          "ROOH" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "XO2" : {} ,
+          "ALD2" : { "yield" : 0.500 } ,
+          "ALDX" : { "yield" : 0.500 }
+        },
+        "orig params" : "CMAQ_1to4(3.01E-12, 0.0E+00, -190.0)",
+        "type" : "ARRHENIUS",
+        "A" : 3.01E-12,
+        "B" : 0.0E+00,
+        "C" : 190.0
+      },
+      {
+        "rxn id" : "R64",
+        "reactants" : {
+          "ROOH" : {}
+        },
+        "products" : {
+          "OH" : {},
+          "HO2" : {} ,
+          "ALD2" : { "yield" : 0.500 } ,
+          "ALDX" : { "yield" : 0.500 }
+        },
+        "orig params" : "TUV_J(26, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R65",
+        "reactants" : {
+          "OH" : {} ,
+          "CO" : {}
+        },
+        "products" : {
+          "HO2" : {}
+        },
+        "orig params" : "CMAQ_9(1.44E-13, 0.0E+00, 3.43E-33, 0.0E+00)",
+        "type" : "CMAQ_H2O2",
+        "k1_A" : 1.44E-13,
+        "k1_C" : 0.0E+00,
+        "k2_A" : 3.43E-33,
+        "k2_C" : 0.0E+00
+      },
+      {
+        "rxn id" : "R66",
+        "reactants" : {
+          "OH" : {} ,
+          "CH4" : {}
+        },
+        "products" : {
+          "MEO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(2.45E-12, 0.0E+00, 1775.0)",
+        "type" : "ARRHENIUS",
+        "A" : 2.45E-12,
+        "B" : 0.0E+00,
+        "C" : -1775.0
+      },
+      {
+        "rxn id" : "R67",
+        "reactants" : {
+          "MEO2" : {} ,
+          "NO" : {}
+        },
+        "products" : {
+          "FORM" : {} ,
+          "HO2" : {} ,
+          "NO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(2.8E-12, 0.0E+00, -300.0)",
+        "type" : "ARRHENIUS",
+        "A" : 2.8E-12,
+        "B" : 0.0E+00,
+        "C" : 300.0
+      },
+      {
+        "rxn id" : "R68",
+        "reactants" : {
+          "MEO2" : {} ,
+          "HO2" : {}
+        },
+        "products" : {
+          "MEPX" : {}
+        },
+        "orig params" : "CMAQ_1to4(4.1E-13, 0.0E+00, -750.0)",
+        "type" : "ARRHENIUS",
+        "A" : 4.1E-13,
+        "B" : 0.0E+00,
+        "C" : 750.0
+      },
+      {
+        "rxn id" : "R69",
+        "reactants" : {
+          "MEO2" : { "qty" : 2 }
+        },
+        "products" : {
+          "FORM" : { "yield" : 1.370 } ,
+          "HO2" : { "yield" : 0.740 } ,
+          "MEOH" : { "yield" : 0.630 }
+        },
+        "orig params" : "CMAQ_1to4(9.5E-14, 0.0E+00, -390.0)",
+        "type" : "ARRHENIUS",
+        "A" : 9.5E-14,
+        "B" : 0.0E+00,
+        "C" : 390.0
+      },
+      {
+        "rxn id" : "R70",
+        "reactants" : {
+          "MEPX" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "MEO2" : { "yield" : 0.700 } ,
+          "XO2" : { "yield" : 0.300 } ,
+          "HO2" : { "yield" : 0.300 }
+        },
+        "orig params" : "CMAQ_1to4(3.8E-12, 0.0E+00, -200.0)",
+        "type" : "ARRHENIUS",
+        "A" : 3.8E-12,
+        "B" : 0.0E+00,
+        "C" : 200.0
+      },
+      {
+        "rxn id" : "R71",
+        "reactants" : {
+          "MEPX" : {}
+        },
+        "products" : {
+          "FORM" : {},
+          "HO2" : {},
+          "OH" : {}
+        },
+        "orig params" : "TUV_J(26, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R72",
+        "reactants" : {
+          "MEOH" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "FORM" : {} ,
+          "HO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(7.3E-12, 0.0E+00, 620.0)",
+        "type" : "ARRHENIUS",
+        "A" : 7.3E-12,
+        "B" : 0.0E+00,
+        "C" : -620.0
+      },
+      {
+        "rxn id" : "R73",
+        "reactants" : {
+          "FORM" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "HO2" : {} ,
+          "CO" : {}
+        },
+        "orig params" : "CMAQ_1to4(9.0E-12, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 9.0E-12,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R74",
+        "reactants" : {
+          "FORM" : {}
+        },
+        "products" : {
+          "HO2" : { "yield" : 2.000 } ,
+          "CO" : {}
+        },
+        "orig params" : "TUV_J(15, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R75",
+        "reactants" : {
+          "FORM" : {}
+        },
+        "products" : {
+          "CO" : {}
+        },
+        "orig params" : "TUV_J(16, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R76",
+        "reactants" : {
+          "FORM" : {} ,
+          "O" : {}
+        },
+        "products" : {
+          "OH" : {} ,
+          "HO2" : {} ,
+          "CO" : {}
+        },
+        "orig params" : "CMAQ_1to4(3.4E-11, 0.0E+00, 1600.0)",
+        "type" : "ARRHENIUS",
+        "A" : 3.4E-11,
+        "B" : 0.0E+00,
+        "C" : -1600.0
+      },
+      {
+        "rxn id" : "R77",
+        "reactants" : {
+          "FORM" : {} ,
+          "NO3" : {}
+        },
+        "products" : {
+          "HNO3" : {} ,
+          "HO2" : {} ,
+          "CO" : {}
+        },
+        "orig params" : "CMAQ_1to4(5.8E-16, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 5.8E-16,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R78",
+        "reactants" : {
+          "FORM" : {} ,
+          "HO2" : {}
+        },
+        "products" : {
+          "HCO3" : {}
+        },
+        "orig params" : "CMAQ_1to4(9.7E-15, 0.0E+00, -625.0)",
+        "type" : "ARRHENIUS",
+        "A" : 9.7E-15,
+        "B" : 0.0E+00,
+        "C" : 625.0
+      },
+      {
+        "rxn id" : "R79",
+        "reactants" : {
+          "HCO3" : {}
+        },
+        "products" : {
+          "FORM" : {} ,
+          "HO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(2.4E+12, 0.0E+00, 7000.0)",
+        "type" : "ARRHENIUS",
+        "A" : 2.4E+12,
+        "B" : 0.0E+00,
+        "C" : -7000.0
+      },
+      {
+        "rxn id" : "R80",
+        "reactants" : {
+          "HCO3" : {} ,
+          "NO" : {}
+        },
+        "products" : {
+          "FACD" : {} ,
+          "NO2" : {} ,
+          "HO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(5.6E-12, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 5.6E-12,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R81",
+        "reactants" : {
+          "HCO3" : {} ,
+          "HO2" : {}
+        },
+        "products" : {
+          "MEPX" : {}
+        },
+        "orig params" : "CMAQ_1to4(5.6E-15, 0.0E+00, -2300.0)",
+        "type" : "ARRHENIUS",
+        "A" : 5.6E-15,
+        "B" : 0.0E+00,
+        "C" : 2300.0
+      },
+      {
+        "rxn id" : "R82",
+        "reactants" : {
+          "FACD" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "HO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(4.0E-13, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 4.0E-13,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R83",
+        "reactants" : {
+          "ALD2" : {} ,
+          "O" : {}
+        },
+        "products" : {
+          "C2O3" : {} ,
+          "OH" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.8E-11, 0.0E+00, 1100.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.8E-11,
+        "B" : 0.0E+00,
+        "C" : -1100.0
+      },
+      {
+        "rxn id" : "R84",
+        "reactants" : {
+          "ALD2" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "C2O3" : {}
+        },
+        "orig params" : "CMAQ_1to4(5.6E-12, 0.0E+00, -270.0)",
+        "type" : "ARRHENIUS",
+        "A" : 5.6E-12,
+        "B" : 0.0E+00,
+        "C" : 270.0
+      },
+      {
+        "rxn id" : "R85",
+        "reactants" : {
+          "ALD2" : {} ,
+          "NO3" : {}
+        },
+        "products" : {
+          "C2O3" : {} ,
+          "HNO3" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.4E-12, 0.0E+00, 1900.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.4E-12,
+        "B" : 0.0E+00,
+        "C" : -1900.0
+      },
+      {
+        "rxn id" : "R86",
+        "reactants" : {
+          "ALD2" : {}
+        },
+        "products" : {
+          "MEO2" : {} ,
+          "CO" : {} ,
+          "HO2" : {}
+        },
+        "orig params" : "TUV_J(17, THETA)+TUV_J(19, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R87",
+        "reactants" : {
+          "C2O3" : {} ,
+          "NO" : {}
+        },
+        "products" : {
+          "MEO2" : {} ,
+          "NO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(8.1E-12, 0.0E+00, -270.0)",
+        "type" : "ARRHENIUS",
+        "A" : 8.1E-12,
+        "B" : 0.0E+00,
+        "C" : 270.0
+      },
+      {
+        "rxn id" : "R88",
+        "reactants" : {
+          "C2O3" : {} ,
+          "NO2" : {}
+        },
+        "products" : {
+          "PAN" : {}
+        },
+        "orig params" : "CMAQ_10(2.7E-28, -7.1, 0.0E+00, 1.2E-11, -0.9, 0.0E+00, 0.3, 1.0)",
+        "type" : "TROE",
+        "k0_A" : 2.7E-28,
+        "k0_B" : -7.1,
+        "k0_C" : -0.0E+00,
+        "kinf_A" : 1.2E-11,
+        "kinf_B" : -0.9,
+        "kinf_C" : -0.0E+00,
+        "Fc" : 0.3,
+        "N" : 1.0
+      },
+      {
+        "rxn id" : "R89",
+        "reactants" : {
+          "PAN" : {}
+        },
+        "products" : {
+          "C2O3" : {} ,
+          "NO2" : {} ,
+          "DUMMY" : {}
+        },
+        "orig params" : "CMAQ_10(4.9E-3, 0.0E+00, 12100.0, 5.4E16, 0.0E+00, 13830.0, 0.3, 1.0)",
+        "type" : "TROE",
+        "k0_A" : 4.9E-3,
+        "k0_B" : 0.0E+00,
+        "k0_C" : -12100.0,
+        "kinf_A" : 5.4E16,
+        "kinf_B" : 0.0E+00,
+        "kinf_C" : -13830.0,
+        "Fc" : 0.3,
+        "N" : 1.0
+      },
+      {
+        "rxn id" : "R90",
+        "reactants" : {
+          "PAN" : {}
+        },
+        "products" : {
+          "C2O3" : {} ,
+          "NO2" : {}
+        },
+        "orig params" : "TUV_J(28, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R91",
+        "reactants" : {
+          "C2O3" : {} ,
+          "HO2" : {}
+        },
+        "products" : {
+          "PACD" : { "yield" : 0.800 } ,
+          "AACD" : { "yield" : 0.200 } ,
+          "O3" : { "yield" : 0.200 }
+        },
+        "orig params" : "CMAQ_1to4(4.3E-13, 0.0E+00, -1040.0)",
+        "type" : "ARRHENIUS",
+        "A" : 4.3E-13,
+        "B" : 0.0E+00,
+        "C" : 1040.0
+      },
+      {
+        "rxn id" : "R92",
+        "reactants" : {
+          "C2O3" : {} ,
+          "MEO2" : {}
+        },
+        "products" : {
+          "MEO2" : { "yield" : 0.900 },
+          "HO2" : { "yield" : 0.900 } ,
+          "FORM" : {},
+          "AACD" : { "yield" : 0.100 }
+        },
+        "orig params" : "CMAQ_1to4(2.0E-12, 0.0E+00, -500.0)",
+        "type" : "ARRHENIUS",
+        "A" : 2.0E-12,
+        "B" : 0.0E+00,
+        "C" : 500.0
+      },
+      {
+        "rxn id" : "R93",
+        "reactants" : {
+          "C2O3" : {} ,
+          "XO2" : {}
+        },
+        "products" : {
+          "MEO2" : { "yield" : 0.900 } ,
+          "AACD" : { "yield" : 0.100 }
+        },
+        "orig params" : "CMAQ_1to4(4.4E-13, 0.0E+00, -1070.0)",
+        "type" : "ARRHENIUS",
+        "A" : 4.4E-13,
+        "B" : 0.0E+00,
+        "C" : 1070.0
+      },
+      {
+        "rxn id" : "R94",
+        "reactants" : {
+          "C2O3" : { "qty" : 2 }
+        },
+        "products" : {
+          "MEO2" : { "yield" : 2.000 }
+        },
+        "orig params" : "CMAQ_1to4(2.9E-12, 0.0E+00, -500.0) {same as IUPAC}",
+        "type" : "ARRHENIUS",
+        "A" : 2.9E-12,
+        "B" : 0.0E+00,
+        "C" : 500.0
+      },
+      {
+        "rxn id" : "R95",
+        "reactants" : {
+          "PACD" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "C2O3" : {}
+        },
+        "orig params" : "CMAQ_1to4(4.0E-13, 0.0E+00, -200.0)",
+        "type" : "ARRHENIUS",
+        "A" : 4.0E-13,
+        "B" : 0.0E+00,
+        "C" : 200.0
+      },
+      {
+        "rxn id" : "R96",
+        "reactants" : {
+          "PACD" : {}
+        },
+        "products" : {
+          "MEO2" : {} ,
+          "OH" : {}
+        },
+        "orig params" : "TUV_J(26, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R97",
+        "reactants" : {
+          "AACD" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "MEO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(4.0E-13, 0.0E+00, -200.0)",
+        "type" : "ARRHENIUS",
+        "A" : 4.0E-13,
+        "B" : 0.0E+00,
+        "C" : 200.0
+      },
+      {
+        "rxn id" : "R98",
+        "reactants" : {
+          "ALDX" : {} ,
+          "O" : {}
+        },
+        "products" : {
+          "CXO3" : {} ,
+          "OH" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.3E-11, 0.0E+00, 870.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.3E-11,
+        "B" : 0.0E+00,
+        "C" : -870.0
+      },
+      {
+        "rxn id" : "R99",
+        "reactants" : {
+          "ALDX" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "CXO3" : {}
+        },
+        "orig params" : "CMAQ_1to4(5.1E-12, 0.0E+00, -405.0)",
+        "type" : "ARRHENIUS",
+        "A" : 5.1E-12,
+        "B" : 0.0E+00,
+        "C" : 405.0
+      },
+      {
+        "rxn id" : "R100",
+        "reactants" : {
+          "ALDX" : {} ,
+          "NO3" : {}
+        },
+        "products" : {
+          "CXO3" : {} ,
+          "HNO3" : {}
+        },
+        "orig params" : "CMAQ_1to4(6.5E-15, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 6.5E-15,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R101",
+        "reactants" : {
+          "ALDX" : {}
+        },
+        "products" : {
+          "MEO2" : {} ,
+          "CO" : {} ,
+          "HO2" : {}
+        },
+        "orig params" : "TUV_J(20, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R102",
+        "reactants" : {
+          "CXO3" : {} ,
+          "NO" : {}
+        },
+        "products" : {
+          "ALD2" : {} ,
+          "NO2" : {} ,
+          "HO2" : {} ,
+          "XO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(6.7E-12, 0.0E+00, -340.0)",
+        "type" : "ARRHENIUS",
+        "A" : 6.7E-12,
+        "B" : 0.0E+00,
+        "C" : 340.0
+      },
+      {
+        "rxn id" : "R103",
+        "reactants" : {
+          "CXO3" : {} ,
+          "NO2" : {}
+        },
+        "products" : {
+          "PANX" : {}
+        },
+        "orig params" : "CMAQ_10(2.7E-28, -7.1, 0.0E+00, 1.2E-11, -0.9, 0.0E+00, 0.3, 1.0)",
+        "type" : "TROE",
+        "k0_A" : 2.7E-28,
+        "k0_B" : -7.1,
+        "k0_C" : -0.0E+00,
+        "kinf_A" : 1.2E-11,
+        "kinf_B" : -0.9,
+        "kinf_C" : -0.0E+00,
+        "Fc" : 0.3,
+        "N" : 1.0
+      },
+      {
+        "rxn id" : "R104",
+        "reactants" : {
+          "PANX" : {}
+        },
+        "products" : {
+          "CXO3" : {} ,
+          "NO2" : {} ,
+          "DUMMY" : {}
+        },
+        "orig params" : "CMAQ_10(4.9E-3, 0.0E+00, 12100.0, 5.4E16, 0.0E+00, 13830.0, 0.3, 1.0)",
+        "type" : "TROE",
+        "k0_A" : 4.9E-3,
+        "k0_B" : 0.0E+00,
+        "k0_C" : -12100.0,
+        "kinf_A" : 5.4E16,
+        "kinf_B" : 0.0E+00,
+        "kinf_C" : -13830.0,
+        "Fc" : 0.3,
+        "N" : 1.0
+      },
+      {
+        "rxn id" : "R105",
+        "reactants" : {
+          "PANX" : {}
+        },
+        "products" : {
+          "CXO3" : {} ,
+          "NO2" : {}
+        },
+        "orig params" : "TUV_J(28, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R106",
+        "reactants" : {
+          "PANX" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "ALD2" : {} ,
+          "NO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(3.0E-13, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 3.0E-13,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R107",
+        "reactants" : {
+          "CXO3" : {} ,
+          "HO2" : {}
+        },
+        "products" : {
+          "PACD" : { "yield" : 0.800 } ,
+          "AACD" : { "yield" : 0.200 } ,
+          "O3" : { "yield" : 0.200 }
+        },
+        "orig params" : "CMAQ_1to4(4.3E-13, 0.0E+00, -1040.0)",
+        "type" : "ARRHENIUS",
+        "A" : 4.3E-13,
+        "B" : 0.0E+00,
+        "C" : 1040.0
+      },
+      {
+        "rxn id" : "R108",
+        "reactants" : {
+          "CXO3" : {} ,
+          "MEO2" : {}
+        },
+        "products" : {
+          "ALD2" : { "yield" : 0.900 } ,
+          "XO2" : { "yield" : 0.900 } ,
+          "HO2" : {} ,
+          "AACD" : { "yield" : 0.100 } ,
+          "FORM" : { "yield" : 0.100 }
+        },
+        "orig params" : "CMAQ_1to4(2.0E-12, 0.0E+00, -500.0)",
+        "type" : "ARRHENIUS",
+        "A" : 2.0E-12,
+        "B" : 0.0E+00,
+        "C" : 500.0
+      },
+      {
+        "rxn id" : "R109",
+        "reactants" : {
+          "CXO3" : {} ,
+          "XO2" : {}
+        },
+        "products" : {
+          "ALD2" : { "yield" : 0.900 } ,
+          "AACD" : { "yield" : 0.100 }
+        },
+        "orig params" : "CMAQ_1to4(4.4E-13, 0.0E+00, -1070.0)",
+        "type" : "ARRHENIUS",
+        "A" : 4.4E-13,
+        "B" : 0.0E+00,
+        "C" : 1070.0
+      },
+      {
+        "rxn id" : "R110",
+        "reactants" : {
+          "CXO3" : { "qty" : 2 }
+        },
+        "products" : {
+          "ALD2" : { "yield" : 2.000 } ,
+          "XO2" : { "yield" : 2.000 } ,
+          "HO2" : { "yield" : 2.000 }
+        },
+        "orig params" : "CMAQ_1to4(2.9E-12, 0.0E+00, -500.0)",
+        "type" : "ARRHENIUS",
+        "A" : 2.9E-12,
+        "B" : 0.0E+00,
+        "C" : 500.0
+      },
+      {
+        "rxn id" : "R111",
+        "reactants" : {
+          "CXO3" : {} ,
+          "C2O3" : {}
+        },
+        "products" : {
+          "MEO2" : {} ,
+          "XO2" : {} ,
+          "HO2" : {} ,
+          "ALD2" : {}
+        },
+        "orig params" : "CMAQ_1to4(2.9E-12, 0.0E+00, -500.0)",
+        "type" : "ARRHENIUS",
+        "A" : 2.9E-12,
+        "B" : 0.0E+00,
+        "C" : 500.0
+      },
+      {
+        "rxn id" : "R112",
+        "reactants" : {
+          "PAR" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "XO2" : { "yield" : 0.870 } ,
+          "XO2N" : { "yield" : 0.130 } ,
+          "HO2" : { "yield" : 0.110 } ,
+          "ALD2" : { "yield" : 0.060 } ,
+          "PAR" : { "yield" : -0.110 } ,
+          "ROR" : { "yield" : 0.760 } ,
+          "ALDX" : { "yield" : 0.050 }
+        },
+        "orig params" : "CMAQ_1to4(8.1E-13, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 8.1E-13,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R113",
+        "reactants" : {
+          "ROR" : {}
+        },
+        "products" : {
+          "XO2" : { "yield" : 0.960 } ,
+          "ALD2" : { "yield" : 0.600 } ,
+          "HO2" : { "yield" : 0.940 } ,
+          "PAR" : { "yield" : -2.100 } ,
+          "XO2N" : { "yield" : 0.040 } ,
+          "ROR" : { "yield" : 0.020 } ,
+          "ALDX" : { "yield" : 0.500 }
+        },
+        "orig params" : "CMAQ_1to4(1.0E+15, 0.0E+00, 8000.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.0E+15,
+        "B" : 0.0E+00,
+        "C" : -8000.0
+      },
+      {
+        "rxn id" : "R114",
+        "reactants" : {
+          "ROR" : {}
+        },
+        "products" : {
+          "HO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.6E+3, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 1.6E+3,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R115",
+        "reactants" : {
+          "ROR" : {} ,
+          "NO2" : {}
+        },
+        "products" : {
+          "NTR" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.5E-11, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 1.5E-11,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R116",
+        "reactants" : {
+          "O" : {} ,
+          "OLE" : {}
+        },
+        "products" : {
+          "ALD2" : { "yield" : 0.200 } ,
+          "ALDX" : { "yield" : 0.300 } ,
+          "HO2" : { "yield" : 0.300 } ,
+          "XO2" : { "yield" : 0.200 } ,
+          "CO" : { "yield" : 0.200 } ,
+          "FORM" : { "yield" : 0.200 } ,
+          "XO2N" : { "yield" : 0.010 } ,
+          "PAR" : { "yield" : 0.200 } ,
+          "OH" : { "yield" : 0.100 }
+        },
+        "orig params" : "CMAQ_1to4(1.0E-11, 0.0E+00, 280.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.0E-11,
+        "B" : 0.0E+00,
+        "C" : -280.0
+      },
+      {
+        "rxn id" : "R117",
+        "reactants" : {
+          "OH" : {} ,
+          "OLE" : {}
+        },
+        "products" : {
+          "FORM" : { "yield" : 0.800 } ,
+          "ALD2" : { "yield" : 0.330 } ,
+          "ALDX" : { "yield" : 0.620 } ,
+          "XO2" : { "yield" : 0.800 } ,
+          "HO2" : { "yield" : 0.950 } ,
+          "PAR" : { "yield" : -0.700 }
+        },
+        "orig params" : "CMAQ_1to4(3.2E-11, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 3.2E-11,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R118",
+        "reactants" : {
+          "O3" : {} ,
+          "OLE" : {}
+        },
+        "products" : {
+          "ALD2" : { "yield" : 0.180 } ,
+          "FORM" : { "yield" : 0.740 } ,
+          "ALDX" : { "yield" : 0.320 } ,
+          "XO2" : { "yield" : 0.220 } ,
+          "OH" : { "yield" : 0.100 } ,
+          "CO" : { "yield" : 0.330 } ,
+          "HO2" : { "yield" : 0.440 } ,
+          "PAR" : { "yield" : -1.000 }
+        },
+        "orig params" : "CMAQ_1to4(6.5E-15, 0.0E+00, 1900.0)",
+        "type" : "ARRHENIUS",
+        "A" : 6.5E-15,
+        "B" : 0.0E+00,
+        "C" : -1900.0
+      },
+      {
+        "rxn id" : "R119",
+        "reactants" : {
+          "NO3" : {} ,
+          "OLE" : {}
+        },
+        "products" : {
+          "NO2" : {} ,
+          "FORM" : {} ,
+          "XO2" : { "yield" : 0.910 } ,
+          "XO2N" : { "yield" : 0.090 } ,
+          "ALDX" : { "yield" : 0.560 } ,
+          "ALD2" : { "yield" : 0.350 } ,
+          "PAR" : { "yield" : -1.000 }
+        },
+        "orig params" : "CMAQ_1to4(7.0E-13, 0.0E+00, 2160.0)",
+        "type" : "ARRHENIUS",
+        "A" : 7.0E-13,
+        "B" : 0.0E+00,
+        "C" : -2160.0
+      },
+      {
+        "rxn id" : "R120",
+        "reactants" : {
+          "O" : {} ,
+          "ETH" : {}
+        },
+        "products" : {
+          "FORM" : {} ,
+          "HO2" : { "yield" : 1.700 } ,
+          "CO" : {} ,
+          "XO2" : { "yield" : 0.700 } ,
+          "OH" : { "yield" : 0.300 }
+        },
+        "orig params" : "CMAQ_1to4(1.04E-11, 0.0E+00, 792.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.04E-11,
+        "B" : 0.0E+00,
+        "C" : -792.0
+      },
+      {
+        "rxn id" : "R121",
+        "reactants" : {
+          "OH" : {} ,
+          "ETH" : {}
+        },
+        "products" : {
+          "XO2" : {} ,
+          "FORM" : { "yield" : 1.560 } ,
+          "ALDX" : { "yield" : 0.220 } ,
+          "HO2" : {}
+        },
+        "orig params" : "CMAQ_10(1.0E-28, -0.8, 0.0E+00, 8.8E-12, 0.0E+00, 0.0E+00, 0.6, 1.0)",
+        "type" : "TROE",
+        "k0_A" : 1.0E-28,
+        "k0_B" : -0.8,
+        "k0_C" : -0.0E+00,
+        "kinf_A" : 8.8E-12,
+        "kinf_B" : 0.0E+00,
+        "kinf_C" : -0.0E+00,
+        "Fc" : 0.6,
+        "N" : 1.0
+      },
+      {
+        "rxn id" : "R122",
+        "reactants" : {
+          "O3" : {} ,
+          "ETH" : {}
+        },
+        "products" : {
+          "FORM" : {} ,
+          "CO" : { "yield" : 0.630 } ,
+          "HO2" : { "yield" : 0.130 } ,
+          "OH" : { "yield" : 0.130 } ,
+          "FACD" : { "yield" : 0.370 }
+        },
+        "orig params" : "CMAQ_1to4(1.2E-14, 0.0E+00, 2630.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.2E-14,
+        "B" : 0.0E+00,
+        "C" : -2630.0
+      },
+      {
+        "rxn id" : "R123",
+        "reactants" : {
+          "NO3" : {} ,
+          "ETH" : {}
+        },
+        "products" : {
+          "NO2" : {} ,
+          "XO2" : {} ,
+          "FORM" : { "yield" : 2.0 }
+        },
+        "orig params" : "CMAQ_1to4(3.3E-12, 0.0E+00, 2880.0)",
+        "type" : "ARRHENIUS",
+        "A" : 3.3E-12,
+        "B" : 0.0E+00,
+        "C" : -2880.0
+      },
+      {
+        "rxn id" : "R124",
+        "reactants" : {
+          "IOLE" : {} ,
+          "O" : {}
+        },
+        "products" : {
+          "ALD2" : { "yield" : 1.240 } ,
+          "ALDX" : { "yield" : 0.660 } ,
+          "HO2" : { "yield" : 0.100 } ,
+          "XO2" : { "yield" : 0.100 } ,
+          "CO" : { "yield" : 0.100 } ,
+          "PAR" : { "yield" : 0.100 }
+        },
+        "orig params" : "CMAQ_1to4(2.3E-11, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 2.3E-11,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R125",
+        "reactants" : {
+          "IOLE" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "ALD2" : { "yield" : 1.300 } ,
+          "ALDX" : { "yield" : 0.700 } ,
+          "HO2" : {},
+          "XO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.0E-11, 0.0E+00, -550.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.0E-11,
+        "B" : 0.0E+00,
+        "C" : 550.0
+      },
+      {
+        "rxn id" : "R126",
+        "reactants" : {
+          "IOLE" : {} ,
+          "O3" : {}
+        },
+        "products" : {
+          "ALD2" : { "yield" : 0.650 } ,
+          "ALDX" : { "yield" : 0.350 } ,
+          "FORM" : { "yield" : 0.250 } ,
+          "CO" : { "yield" : 0.250 } ,
+          "O" : { "yield" : 0.500 } ,
+          "OH" : { "yield" : 0.500 } ,
+          "HO2" : { "yield" : 0.500 }
+        },
+        "orig params" : "CMAQ_1to4(8.4E-15, 0.0E+00, 1100.0)",
+        "type" : "ARRHENIUS",
+        "A" : 8.4E-15,
+        "B" : 0.0E+00,
+        "C" : -1100.0
+      },
+      {
+        "rxn id" : "R127",
+        "reactants" : {
+          "IOLE" : {} ,
+          "NO3" : {}
+        },
+        "products" : {
+          "ALD2" : { "yield" : 1.180 } ,
+          "ALDX" : { "yield" : 0.640 } ,
+          "HO2" : {} ,
+          "NO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(9.6E-13, 0.0E+00, 270.0)",
+        "type" : "ARRHENIUS",
+        "A" : 9.6E-13,
+        "B" : 0.0E+00,
+        "C" : -270.0
+      },
+      {
+        "rxn id" : "R128",
+        "reactants" : {
+          "TOL" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "HO2" : { "yield" : 0.440 } ,
+          "XO2" : { "yield" : 0.080 } ,
+          "CRES" : { "yield" : 0.360 } ,
+          "TO2" : { "yield" : 0.560 } ,
+          "TOLRO2" : { "yield" : 0.765 }
+        },
+        "orig params" : "CMAQ_1to4(1.8E-12, 0.0E+00, -355.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.8E-12,
+        "B" : 0.0E+00,
+        "C" : 355.0
+      },
+      {
+        "rxn id" : "R129",
+        "reactants" : {
+          "TO2" : {} ,
+          "NO" : {}
+        },
+        "products" : {
+          "NO2" : { "yield" : 0.900 } ,
+          "HO2" : { "yield" : 0.900 } ,
+          "OPEN" : { "yield" : 0.900 } ,
+          "NTR" : { "yield" : 0.100 }
+        },
+        "orig params" : "CMAQ_1to4(8.1E-12, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 8.1E-12,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R130",
+        "reactants" : {
+          "TO2" : {}
+        },
+        "products" : {
+          "CRES" : {} ,
+          "HO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(4.2E+00, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 4.2E+00,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R131",
+        "reactants" : {
+          "OH" : {} ,
+          "CRES" : {}
+        },
+        "products" : {
+          "CRO" : { "yield" : 0.400 } ,
+          "XO2" : { "yield" : 0.600 } ,
+          "HO2" : { "yield" : 0.600 } ,
+          "OPEN" : { "yield" : 0.300 }
+        },
+        "orig params" : "CMAQ_1to4(4.1E-11, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 4.1E-11,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R132",
+        "reactants" : {
+          "CRES" : {} ,
+          "NO3" : {}
+        },
+        "products" : {
+          "CRO" : {} ,
+          "HNO3" : {}
+        },
+        "orig params" : "CMAQ_1to4(2.2E-11, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 2.2E-11,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R133",
+        "reactants" : {
+          "CRO" : {} ,
+          "NO2" : {}
+        },
+        "products" : {
+          "NTR" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.4E-11, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 1.4E-11,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R134",
+        "reactants" : {
+          "CRO" : {} ,
+          "HO2" : {}
+        },
+        "products" : {
+          "CRES" : {}
+        },
+        "orig params" : "CMAQ_1to4(5.5E-12, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 5.5E-12,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R135",
+        "reactants" : {
+          "OPEN" : {}
+        },
+        "products" : {
+          "C2O3" : {} ,
+          "HO2" : {} ,
+          "CO" : {}
+        },
+	"scaling factor" : 9.0,
+        "orig params" : "9.0 * TUV_J(15, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R136",
+        "reactants" : {
+          "OPEN" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "XO2" : {} ,
+          "CO" : { "yield" : 2.000 } ,
+          "HO2" : { "yield" : 2.000 } ,
+          "C2O3" : {} ,
+          "FORM" : {}
+        },
+        "orig params" : "CMAQ_1to4(3.0E-11, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 3.0E-11,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R137",
+        "reactants" : {
+          "OPEN" : {} ,
+          "O3" : {}
+        },
+        "products" : {
+          "ALDX" : { "yield" : 0.030 } ,
+          "C2O3" : { "yield" : 0.620 } ,
+          "FORM" : { "yield" : 0.700 } ,
+          "XO2" : { "yield" : 0.030 } ,
+          "CO" : { "yield" : 0.690 } ,
+          "OH" : { "yield" : 0.080 } ,
+          "HO2" : { "yield" : 0.760 } ,
+          "MGLY" : { "yield" : 0.200 }
+        },
+        "orig params" : "CMAQ_1to4(5.4E-17, 0.0E+00, 500.0)",
+        "type" : "ARRHENIUS",
+        "A" : 5.4E-17,
+        "B" : 0.0E+00,
+        "C" : -500.0
+      },
+      {
+        "rxn id" : "R138",
+        "reactants" : {
+          "OH" : {} ,
+          "XYL" : {}
+        },
+        "products" : {
+          "HO2" : { "yield" : 0.700 } ,
+          "XO2" : { "yield" : 0.500 } ,
+          "CRES" : { "yield" : 0.200 } ,
+          "MGLY" : { "yield" : 0.800 } ,
+          "PAR" : { "yield" : 1.100 } ,
+          "TO2" : { "yield" : 0.300 } ,
+          "XYLRO2" : { "yield" : 0.804 }
+        },
+        "orig params" : "CMAQ_1to4(1.7E-11, 0.0E+00, -116.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.7E-11,
+        "B" : 0.0E+00,
+        "C" : 116.0
+      },
+      {
+        "rxn id" : "R139",
+        "reactants" : {
+          "OH" : {} ,
+          "MGLY" : {}
+        },
+        "products" : {
+          "XO2" : {} ,
+          "C2O3" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.8E-11, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 1.8E-11,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R140",
+        "reactants" : {
+          "MGLY" : {}
+        },
+        "products" : {
+          "C2O3" : {} ,
+          "HO2" : {} ,
+          "CO" : {}
+        },
+        "orig params" : "TUV_J(24, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R141",
+        "reactants" : {
+          "O" : {} ,
+          "ISOP" : {}
+        },
+        "products" : {
+          "ISPD" : { "yield" : 0.750 } ,
+          "FORM" : { "yield" : 0.500 } ,
+          "XO2" : { "yield" : 0.250 } ,
+          "HO2" : { "yield" : 0.250 } ,
+          "CXO3" : { "yield" : 0.250 } ,
+          "PAR" : { "yield" : 0.250 }
+        },
+        "orig params" : "CMAQ_1to4(3.6E-11, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 3.6E-11,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R142",
+        "reactants" : {
+          "OH" : {} ,
+          "ISOP" : {}
+        },
+        "products" : {
+          "ISPD" : { "yield" : 0.912 } ,
+          "FORM" : { "yield" : 0.629 } ,
+          "XO2" : { "yield" : 0.991 } ,
+          "HO2" : { "yield" : 0.912 } ,
+          "XO2N" : { "yield" : 0.088 },
+          "ISOPRXN" : {}
+        },
+        "orig params" : "CMAQ_1to4(2.54E-11, 0.0E+00, -407.6)",
+        "type" : "ARRHENIUS",
+        "A" : 2.54E-11,
+        "B" : 0.0E+00,
+        "C" : 407.6
+      },
+      {
+        "rxn id" : "R143",
+        "reactants" : {
+          "O3" : {} ,
+          "ISOP" : {}
+        },
+        "products" : {
+          "ISPD" : { "yield" : 0.650 } ,
+          "FORM" : { "yield" : 0.600 } ,
+          "XO2" : { "yield" : 0.200 } ,
+          "HO2" : { "yield" : 0.066 } ,
+          "OH" : { "yield" : 0.266 } ,
+          "CXO3" : { "yield" : 0.200 } ,
+          "ALDX" : { "yield" : 0.150 } ,
+          "PAR" : { "yield" : 0.350 } ,
+          "CO" : { "yield" : 0.066 }
+        },
+        "orig params" : "CMAQ_1to4(7.86E-15, 0.0E+00, 1912.0)",
+        "type" : "ARRHENIUS",
+        "A" : 7.86E-15,
+        "B" : 0.0E+00,
+        "C" : -1912.0
+      },
+      {
+        "rxn id" : "R144",
+        "reactants" : {
+          "NO3" : {} ,
+          "ISOP" : {}
+        },
+        "products" : {
+          "ISPD" : { "yield" : 0.200 } ,
+          "NTR" : { "yield" : 0.800 } ,
+          "XO2" : {} ,
+          "HO2" : { "yield" : 0.800 } ,
+          "NO2" : { "yield" : 0.200 } ,
+          "ALDX" : { "yield" : 0.800 } ,
+          "PAR" : { "yield" : 2.400 }
+        },
+        "orig params" : "CMAQ_1to4(3.03E-12, 0.0E+00, 448.0)",
+        "type" : "ARRHENIUS",
+        "A" : 3.03E-12,
+        "B" : 0.0E+00,
+        "C" : -448.0
+      },
+      {
+        "rxn id" : "R145",
+        "reactants" : {
+          "OH" : {} ,
+          "ISPD" : {}
+        },
+        "products" : {
+          "PAR" : { "yield" : 1.565 } ,
+          "FORM" : { "yield" : 0.167 } ,
+          "XO2" : { "yield" : 0.713 } ,
+          "HO2" : { "yield" : 0.503 } ,
+          "CO" : { "yield" : 0.334 } ,
+          "MGLY" : { "yield" : 0.168 } ,
+          "ALD2" : { "yield" : 0.252 } ,
+          "C2O3" : { "yield" : 0.210 } ,
+          "CXO3" : { "yield" : 0.250 } ,
+          "ALDX" : { "yield" : 0.120 }
+        },
+        "orig params" : "CMAQ_1to4(3.36E-11, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 3.36E-11,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R146",
+        "reactants" : {
+          "O3" : {} ,
+          "ISPD" : {}
+        },
+        "products" : {
+          "C2O3" : { "yield" : 0.114 } ,
+          "FORM" : { "yield" : 0.150 } ,
+          "MGLY" : { "yield" : 0.850 } ,
+          "HO2" : { "yield" : 0.154 } ,
+          "OH" : { "yield" : 0.268 } ,
+          "XO2" : { "yield" : 0.064 } ,
+          "ALD2" : { "yield" : 0.020 } ,
+          "PAR" : { "yield" : 0.360 } ,
+          "CO" : { "yield" : 0.225 }
+        },
+        "orig params" : "CMAQ_1to4(7.1E-18, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 7.1E-18,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R147",
+        "reactants" : {
+          "NO3" : {} ,
+          "ISPD" : {}
+        },
+        "products" : {
+          "ALDX" : { "yield" : 0.357 } ,
+          "FORM" : { "yield" : 0.282 } ,
+          "PAR" : { "yield" : 1.282 } ,
+          "HO2" : { "yield" : 0.925 } ,
+          "CO" : { "yield" : 0.643 } ,
+          "NTR" : { "yield" : 0.850 } ,
+          "CXO3" : { "yield" : 0.075 } ,
+          "XO2" : { "yield" : 0.075 } ,
+          "HNO3" : { "yield" : 0.150 }
+        },
+        "orig params" : "CMAQ_1to4(1.0E-15, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 1.0E-15,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R148",
+        "reactants" : {
+          "ISPD" : {}
+        },
+        "products" : {
+          "CO" : { "yield" : 0.333 } ,
+          "ALD2" : { "yield" : 0.067 },
+          "FORM" : { "yield" : 0.900 } ,
+          "PAR" : { "yield" : 0.832 },
+          "HO2" : { "yield" : 1.033 } ,
+          "XO2" : { "yield" : 0.700 },
+          "C2O3" : { "yield" : 0.967 }
+        },
+	"scaling factor" : 0.0036,
+        "orig params" : "0.0036 * TUV_J(89, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "R149",
+        "reactants" : {
+          "TERP" : {} ,
+          "O" : {}
+        },
+        "products" : {
+          "ALDX" : { "yield" : 0.150 } ,
+          "PAR" : { "yield" : 5.12 } ,
+          "TRPRXN" : {}
+        },
+        "orig params" : "CMAQ_1to4(3.6E-11, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 3.6E-11,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "R150",
+        "reactants" : {
+          "TERP" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "HO2" : { "yield" : 0.750 } ,
+          "XO2" : { "yield" : 1.250 } ,
+          "XO2N" : { "yield" : 0.250 } ,
+          "FORM" : { "yield" : 0.280 },
+          "PAR" : { "yield" : 1.66 } ,
+          "ALDX" : { "yield" : 0.470 } ,
+          "TRPRXN" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.5E-11, 0.0E+00, -449.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.5E-11,
+        "B" : 0.0E+00,
+        "C" : 449.0
+      },
+      {
+        "rxn id" : "R151",
+        "reactants" : {
+          "TERP" : {} ,
+          "O3" : {}
+        },
+        "products" : {
+          "OH" : { "yield" : 0.570 } ,
+          "HO2" : { "yield" : 0.070 } ,
+          "XO2" : { "yield" : 0.760 } ,
+          "XO2N" : { "yield" : 0.180 } ,
+          "FORM" : { "yield" : 0.240 } ,
+          "CO" : { "yield" : 0.001 } ,
+          "PAR" : { "yield" : 7.000 } ,
+          "ALDX" : { "yield" : 0.210 } ,
+          "CXO3" : { "yield" : 0.390 },
+          "TRPRXN" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.2E-15, 0.0E+00, 821.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.2E-15,
+        "B" : 0.0E+00,
+        "C" : -821.0
+      },
+      {
+        "rxn id" : "R152",
+        "reactants" : {
+          "TERP" : {} ,
+          "NO3" : {}
+        },
+        "products" : {
+          "NO2" : { "yield" : 0.470 } ,
+          "HO2" : { "yield" : 0.280 } ,
+          "XO2" : { "yield" : 1.030 } ,
+          "XO2N" : { "yield" : 0.250 } ,
+          "ALDX" : { "yield" : 0.470 } ,
+          "NTR" : { "yield" : 0.530 },
+          "TRPRXN" : {}
+        },
+        "orig params" : "CMAQ_1to4(3.7E-12, 0.0E+00, -175.0)",
+        "type" : "ARRHENIUS",
+        "A" : 3.7E-12,
+        "B" : 0.0E+00,
+        "C" : 175.0
+      },
+      {
+        "rxn id" : "R153",
+        "reactants" : {
+          "SO2" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "SULF" : {} ,
+          "HO2" : {} ,
+          "SULRXN" : {}
+        },
+        "orig params" : "CMAQ_10(3.0E-31, -3.3, 0.0E+00, 1.5E-12, 0.0E+00, 0.0E+00, 0.6, 1.0)",
+        "type" : "TROE",
+        "k0_A" : 3.0E-31,
+        "k0_B" : -3.3,
+        "k0_C" : -0.0E+00,
+        "kinf_A" : 1.5E-12,
+        "kinf_B" : 0.0E+00,
+        "kinf_C" : -0.0E+00,
+        "Fc" : 0.6,
+        "N" : 1.0
+      },
+      {
+        "rxn id" : "R154",
+        "reactants" : {
+          "OH" : {} ,
+          "ETOH" : {}
+        },
+        "products" : {
+          "HO2" : {} ,
+          "ALD2" : { "yield" : 0.900 } ,
+          "ALDX" : { "yield" : 0.050 } ,
+          "FORM" : { "yield" : 0.100 } ,
+          "XO2" : { "yield" : 0.100 }
+        },
+        "orig params" : "CMAQ_1to4(6.9E-12, 0.0E+00, 230.0)",
+        "type" : "ARRHENIUS",
+        "A" : 6.9E-12,
+        "B" : 0.0E+00,
+        "C" : -230.0
+      },
+      {
+        "rxn id" : "R155",
+        "reactants" : {
+          "OH" : {} ,
+          "ETHA" : {}
+        },
+        "products" : {
+          "ALD2" : { "yield" : 0.991 } ,
+          "XO2" : { "yield" : 0.991 } ,
+          "XO2N" : { "yield" : 0.009 } ,
+          "HO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(8.7E-12, 0.0E+00, 1070.0)",
+        "type" : "ARRHENIUS",
+        "A" : 8.7E-12,
+        "B" : 0.0E+00,
+        "C" : -1070.0
+      },
+      {
+        "rxn id" : "R156",
+        "reactants" : {
+          "NO2" : {} ,
+          "ISOP" : {}
+        },
+        "products" : {
+          "ISPD" : { "yield" : 0.200 } ,
+          "NTR" : { "yield" : 0.800 } ,
+          "XO2" : {} ,
+          "HO2" : { "yield" : 0.800 } ,
+          "NO" : { "yield" : 0.200 } ,
+          "ALDX" : { "yield" : 0.800 } ,
+          "PAR" : { "yield" : 2.400 }
+        },
+        "orig params" : "CMAQ_1to4(1.5E-19, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 1.5E-19,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "CL1",
+        "reactants" : {
+          "CL2" : {}
+        },
+        "products" : {
+          "CL" : { "yield" : 2.000 }
+        },
+        "orig params" : "TUV_J(58, THETA)",
+        "type" : "PHOTOLYSIS"
+      },
+      {
+        "rxn id" : "CL3",
+        "reactants" : {
+          "CL" : {} ,
+          "O3" : {}
+        },
+        "products" : {
+          "CLO" : {}
+        },
+        "orig params" : "CMAQ_1to4(2.3E-11, 0.0E+00, 200.0)",
+        "type" : "ARRHENIUS",
+        "A" : 2.3E-11,
+        "B" : 0.0E+00,
+        "C" : -200.0
+      },
+      {
+        "rxn id" : "CL4",
+        "reactants" : {
+          "CLO" : { "qty" : 2 }
+        },
+        "products" : {
+          "CL2" : { "yield" : 0.300 } ,
+          "CL" : { "yield" : 1.400 }
+        },
+        "orig params" : "CMAQ_1to4(1.63E-14, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 1.63E-14,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "CL5",
+        "reactants" : {
+          "CLO" : {} ,
+          "NO" : {}
+        },
+        "products" : {
+          "CL" : {} ,
+          "NO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(6.4E-12, 0.0E+00, -290.0)",
+        "type" : "ARRHENIUS",
+        "A" : 6.4E-12,
+        "B" : 0.0E+00,
+        "C" : 290.0
+      },
+      {
+        "rxn id" : "CL6",
+        "reactants" : {
+          "CLO" : {} ,
+          "HO2" : {}
+        },
+        "products" : {
+          "HOCL" : {}
+        },
+        "orig params" : "CMAQ_1to4(2.7E-12, 0.0E+00, -220.0)",
+        "type" : "ARRHENIUS",
+        "A" : 2.7E-12,
+        "B" : 0.0E+00,
+        "C" : 220.0
+      },
+      {
+        "rxn id" : "CL7",
+        "reactants" : {
+          "OH" : {} ,
+          "FMCL" : {}
+        },
+        "products" : {
+          "CL" : {} ,
+          "CO" : {}
+        },
+        "orig params" : "CMAQ_1to4(5.0E-13, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 5.0E-13,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "CL9",
+        "reactants" : {
+          "CL" : {} ,
+          "CH4" : {}
+        },
+        "products" : {
+          "HCL" : {} ,
+          "MEO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(6.6E-12, 0.0E+00, 1240.0)",
+        "type" : "ARRHENIUS",
+        "A" : 6.6E-12,
+        "B" : 0.0E+00,
+        "C" : -1240.0
+      },
+      {
+        "rxn id" : "CL10",
+        "reactants" : {
+          "CL" : {} ,
+          "PAR" : {}
+        },
+        "products" : {
+          "HCL" : {} ,
+          "XO2" : { "yield" : 0.870 } ,
+          "XO2N" : { "yield" : 0.130 } ,
+          "HO2" : { "yield" : 0.110 } ,
+          "ALD2" : { "yield" : 0.060 } ,
+          "PAR" : { "yield" : -0.110 } ,
+          "ROR" : { "yield" : 0.760 } ,
+          "ALDX" : { "yield" : 0.050 }
+        },
+        "orig params" : "CMAQ_1to4(5.0E-11, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 5.0E-11,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "CL11",
+        "reactants" : {
+          "CL" : {} ,
+          "ETHA" : {}
+        },
+        "products" : {
+          "HCL" : {} ,
+          "ALD2" : { "yield" : 0.991 } ,
+          "XO2" : { "yield" : 0.991 } ,
+          "XO2N" : { "yield" : 0.009 } ,
+          "HO2" : {}
+        },
+        "orig params" : "CMAQ_1to4(8.3E-11, 0.0E+00, 100.0)",
+        "type" : "ARRHENIUS",
+        "A" : 8.3E-11,
+        "B" : 0.0E+00,
+        "C" : -100.0
+      },
+      {
+        "rxn id" : "CL12",
+        "reactants" : {
+          "CL" : {} ,
+          "ETH" : {}
+        },
+        "products" : {
+          "FMCL" : {} ,
+          "XO2" : { "yield" : 2.000 } ,
+          "HO2" : { "yield" : 1.000 } ,
+          "FORM" : { "yield" : 1.000 }
+        },
+        "orig params" : "CMAQ_1to4(1.07E-10, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 1.07E-10,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "CL13",
+        "reactants" : {
+          "CL" : {} ,
+          "OLE" : {}
+        },
+        "products" : {
+          "FMCL" : {} ,
+          "ALD2" : { "yield" : 0.330 } ,
+          "ALDX" : { "yield" : 0.670 } ,
+          "XO2" : { "yield" : 2.000 } ,
+          "HO2" : { "yield" : 1.000 } ,
+          "PAR" : { "yield" : -1.000 }
+        },
+        "orig params" : "CMAQ_1to4(2.5E-10, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 2.5E-10,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "CL14",
+        "reactants" : {
+          "CL" : {} ,
+          "IOLE" : {}
+        },
+        "products" : {
+          "HCL" : { "yield" : 0.300 } ,
+          "FMCL" : { "yield" : 0.700 } ,
+          "ALD2" : { "yield" : 0.450 } ,
+          "ALDX" : { "yield" : 0.550 } ,
+          "OLE" : { "yield" : 0.300 } ,
+          "PAR" : { "yield" : 0.300 } ,
+          "XO2" : { "yield" : 1.700 } ,
+          "HO2" : { "yield" : 1.000 }
+        },
+        "orig params" : "CMAQ_1to4(3.5E-10, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 3.5E-10,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "CL15",
+        "reactants" : {
+          "CL" : {} ,
+          "ISOP" : {}
+        },
+        "products" : {
+          "HCL" : { "yield" : 0.15 } ,
+          "XO2" : { "yield" : 1.000 } ,
+          "HO2" : { "yield" : 1.000 } ,
+          "FMCL" : { "yield" : 0.850 } ,
+          "ISPD" : { "yield" : 1.000 }
+        },
+        "orig params" : "CMAQ_1to4(4.3E-10, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 4.3E-10,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "CL16",
+        "reactants" : {
+          "CL" : {} ,
+          "FORM" : {}
+        },
+        "products" : {
+          "HCL" : {} ,
+          "HO2" : { "yield" : 1.000 },
+          "CO" : { "yield" : 1.000 }
+        },
+        "orig params" : "CMAQ_1to4(8.2E-11, 0.0E+00, 34.0)",
+        "type" : "ARRHENIUS",
+        "A" : 8.2E-11,
+        "B" : 0.0E+00,
+        "C" : -34.0
+      },
+      {
+        "rxn id" : "CL17",
+        "reactants" : {
+          "CL" : {} ,
+          "ALD2" : {}
+        },
+        "products" : {
+          "HCL" : {} ,
+          "C2O3" : { "yield" : 1.000 }
+        },
+        "orig params" : "CMAQ_1to4(7.9E-11, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 7.9E-11,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "CL18",
+        "reactants" : {
+          "CL" : {} ,
+          "ALDX" : {}
+        },
+        "products" : {
+          "HCL" : {} ,
+          "CXO3" : { "yield" : 1.000 }
+        },
+        "orig params" : "CMAQ_1to4(1.3E-10, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 1.3E-10,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "CL19",
+        "reactants" : {
+          "CL" : {} ,
+          "MEOH" : {}
+        },
+        "products" : {
+          "HCL" : {} ,
+          "HO2" : { "yield" : 1.000 },
+          "FORM" : { "yield" : 1.000 }
+        },
+        "orig params" : "CMAQ_1to4(5.5E-11, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 5.5E-11,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "CL20",
+        "reactants" : {
+          "CL" : {} ,
+          "ETOH" : {}
+        },
+        "products" : {
+          "HCL" : {} ,
+          "HO2" : { "yield" : 1.000 },
+          "ALD2" : { "yield" : 1.000 }
+        },
+        "orig params" : "CMAQ_1to4(8.2E-11, 0.0E+00, -45.0)",
+        "type" : "ARRHENIUS",
+        "A" : 8.2E-11,
+        "B" : 0.0E+00,
+        "C" : 45.0
+      },
+      {
+        "rxn id" : "CL21",
+        "reactants" : {
+          "HCL" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "CL" : {}
+        },
+        "orig params" : "CMAQ_1to4(6.58E-13, 1.16, -58.0)",
+        "type" : "ARRHENIUS",
+        "A" : 6.58E-13,
+        "B" : 1.16,
+        "C" : 58.0
+      },
+      {
+        "rxn id" : "SA01",
+        "reactants" : {
+          "TOLRO2" : {} ,
+          "NO" : {}
+        },
+        "products" : {
+          "NO" : {} ,
+          "TOLNRXN" : {}
+        },
+        "orig params" : "CMAQ_1to4(2.70e-12, 0.0E+00, -360.0)",
+        "type" : "ARRHENIUS",
+        "A" : 2.70e-12,
+        "B" : 0.0E+00,
+        "C" : 360.0
+      },
+      {
+        "rxn id" : "SA02",
+        "reactants" : {
+          "TOLRO2" : {} ,
+          "HO2" : {}
+        },
+        "products" : {
+          "HO2" : {} ,
+          "TOLHRXN" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.90e-13, 0.0E+00, -1300.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.90e-13,
+        "B" : 0.0E+00,
+        "C" : 1300.0
+      },
+      {
+        "rxn id" : "SA03",
+        "reactants" : {
+          "XYLRO2" : {} ,
+          "NO" : {}
+        },
+        "products" : {
+          "NO" : {} ,
+          "XYLNRXN" : {}
+        },
+        "orig params" : "CMAQ_1to4(2.70e-12, 0.0E+00, -360.0)",
+        "type" : "ARRHENIUS",
+        "A" : 2.70e-12,
+        "B" : 0.0E+00,
+        "C" : 360.0
+      },
+      {
+        "rxn id" : "SA04",
+        "reactants" : {
+          "XYLRO2" : {} ,
+          "HO2" : {}
+        },
+        "products" : {
+          "HO2" : {} ,
+          "XYLHRXN" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.90e-13, 0.0E+00, -1300.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.90e-13,
+        "B" : 0.0E+00,
+        "C" : 1300.0
+      },
+      {
+        "rxn id" : "SA05",
+        "reactants" : {
+          "BENZENE" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "OH" : {} ,
+          "BENZRO2" : { "yield" : 0.764 }
+        },
+        "orig params" : "CMAQ_1to4(2.47e-12, 0.0E+00, 206.0)",
+        "type" : "ARRHENIUS",
+        "A" : 2.47e-12,
+        "B" : 0.0E+00,
+        "C" : -206.0
+      },
+      {
+        "rxn id" : "SA06",
+        "reactants" : {
+          "BENZRO2" : {} ,
+          "NO" : {}
+        },
+        "products" : {
+          "NO" : {} ,
+          "BNZNRXN" : {}
+        },
+        "orig params" : "CMAQ_1to4(2.70e-12, 0.0E+00, -360.0)",
+        "type" : "ARRHENIUS",
+        "A" : 2.70e-12,
+        "B" : 0.0E+00,
+        "C" : 360.0
+      },
+      {
+        "rxn id" : "SA07",
+        "reactants" : {
+          "BENZRO2" : {} ,
+          "HO2" : {}
+        },
+        "products" : {
+          "HO2" : {} ,
+          "BNZHRXN" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.90e-13, 0.0E+00, -1300.0)",
+        "type" : "ARRHENIUS",
+        "A" : 1.90e-13,
+        "B" : 0.0E+00,
+        "C" : 1300.0
+      },
+      {
+        "rxn id" : "SA08",
+        "reactants" : {
+          "SESQ" : {} ,
+          "O3" : {}
+        },
+        "products" : {
+          "O3" : {} ,
+          "SESQRXN" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.16E-14, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 1.16E-14,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "SA09",
+        "reactants" : {
+          "SESQ" : {} ,
+          "OH" : {}
+        },
+        "products" : {
+          "OH" : {} ,
+          "SESQRXN" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.97E-10, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 1.97E-10,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "SA10",
+        "reactants" : {
+          "SESQ" : {} ,
+          "NO3" : {}
+        },
+        "products" : {
+          "NO3" : {} ,
+          "SESQRXN" : {}
+        },
+        "orig params" : "CMAQ_1to4(1.90E-11, 0.0E+00, 0.0E+00)",
+        "type" : "ARRHENIUS",
+        "A" : 1.90E-11,
+        "B" : 0.0E+00,
+        "C" : -0.0E+00
+      },
+      {
+        "rxn id" : "jo2",
+        "reactants" : {
+          "O2" : {}
+        },
+        "products" : {
+          "O" : { "yield" : 2 }
+        },
+        "orig params" : "TUV_J(1, THETA)",
+        "type" : "PHOTOLYSIS"
+      }
+    ]
+}
+]}

--- a/src/examples/runs/atmospheric_chemistry/CB05CL_AE5/CAMP/cb05cl_ae5_species.json
+++ b/src/examples/runs/atmospheric_chemistry/CB05CL_AE5/CAMP/cb05cl_ae5_species.json
@@ -1,0 +1,399 @@
+{
+"notes" :"Descriptions are from CB5 Final Report RT-04-00675 (www.camx.com/files/cb05_final_report_120805.aspx) and from notes in the cb05cl_ae5_aq_CMAQ.def mechanism file",
+"camp-data" : [
+  {
+    "name" : "AACD",
+    "type" : "CHEM_SPEC",
+    "description" : "acetic and higher carboxylic acids"
+  },
+  {
+    "name" : "ALD2",
+    "type" : "CHEM_SPEC",
+    "description" : "acetaldehyde"
+  },
+  {
+    "name" : "ALDX",
+    "type" : "CHEM_SPEC",
+    "description" : "propionaldehyde and higher aldehydes"
+  },
+  {
+    "name" : "BENZENE",
+    "type" : "CHEM_SPEC",
+    "description" : "benzene"
+  },
+  {
+    "name" : "BENZRO2",
+    "type" : "CHEM_SPEC",
+    "description" : "peroxy radical from benzene oxidation"
+  },
+  {
+    "name" : "BNZHRXN",
+    "type" : "CHEM_SPEC",
+    "description" : "counter species for aerosol from BENZENE - how does this differ from BNZNNRXN?"
+  },
+  {
+    "name" : "BNZNRXN",
+    "type" : "CHEM_SPEC",
+    "description" : "counter species for aerosol from BENZENE"
+  },
+  {
+    "name" : "C2O3",
+    "type" : "CHEM_SPEC",
+    "description" : "acetyl peroxy radical"
+  },
+  {
+    "name" : "CH4",
+    "type" : "CHEM_SPEC",
+    "description" : "methane"
+  },
+  {
+    "name" : "CL",
+    "type" : "CHEM_SPEC",
+    "description" : "chlorine radical"
+  },
+  {
+    "name" : "CL2",
+    "type" : "CHEM_SPEC",
+    "description" : "molecular chlorine"
+  },
+  {
+    "name" : "CLO",
+    "type" : "CHEM_SPEC",
+    "description" : "chlorine monoxide"
+  },
+  {
+    "name" : "CO",
+    "type" : "CHEM_SPEC",
+    "description" : "carbon monoxide"
+  },
+  {
+    "name" : "CRES",
+    "type" : "CHEM_SPEC",
+    "description" : "cresol and higher molecular weight phenols"
+  },
+  {
+    "name" : "CRO",
+    "type" : "CHEM_SPEC",
+    "description" : "methylphenoxy radical"
+  },
+  {
+    "name" : "CXO3",
+    "type" : "CHEM_SPEC",
+    "description" : "C3 and higher acylperoxy radicals"
+  },
+  {
+    "name" : "ETH",
+    "type" : "CHEM_SPEC",
+    "description" : "ethene"
+  },
+  {
+    "name" : "ETHA",
+    "type" : "CHEM_SPEC",
+    "description" : "ethane"
+  },
+  {
+    "name" : "ETOH",
+    "type" : "CHEM_SPEC",
+    "description" : "ethanol"
+  },
+  {
+    "name" : "FACD",
+    "type" : "CHEM_SPEC",
+    "description" : "formic acid"
+  },
+  {
+    "name" : "FMCL",
+    "type" : "CHEM_SPEC",
+    "description" : "formyl chloride (HC(O)Cl)"
+  },
+  {
+    "name" : "FORM",
+    "type" : "CHEM_SPEC",
+    "description" : "formaldehyde"
+  },
+  {
+    "name" : "H2O2",
+    "type" : "CHEM_SPEC",
+    "description" : "hydrogen peroxide"
+  },
+  {
+    "name" : "HCL",
+    "type" : "CHEM_SPEC",
+    "description" : "hydrochlric acid"
+  },
+  {
+    "name" : "HCO3",
+    "type" : "CHEM_SPEC",
+    "description" : "formyl peroxy radical? no description in cb05 report"
+  },
+  {
+    "name" : "HNO3",
+    "type" : "CHEM_SPEC",
+    "description" : "nitric acid"
+  },
+  {
+    "name" : "HO2",
+    "type" : "CHEM_SPEC",
+    "description" : "hydroperoxy radical"
+  },
+  {
+    "name" : "HOCL",
+    "type" : "CHEM_SPEC",
+    "description" : "hypochlorous acid"
+  },
+  {
+    "name" : "HONO",
+    "type" : "CHEM_SPEC",
+    "description" : "nitrous acid"
+  },
+  {
+    "name" : "IOLE",
+    "type" : "CHEM_SPEC",
+    "description" : "internal olefin carbon bond (R-C=C)"
+  },
+  {
+    "name" : "ISOP",
+    "type" : "CHEM_SPEC",
+    "description" : "isoprene"
+  },
+  {
+    "name" : "ISOPRXN",
+    "type" : "CHEM_SPEC",
+    "description" : "counter for aerosol from ISOP"
+  },
+  {
+    "name" : "ISPD",
+    "type" : "CHEM_SPEC",
+    "description" : "isoprene products (lumped methacrolein, methyl vinyl ketone, etc.)"
+  },
+  {
+    "name" : "MEO2",
+    "type" : "CHEM_SPEC",
+    "description" : "methyl peroxy radical"
+  },
+  {
+    "name" : "MEOH",
+    "type" : "CHEM_SPEC",
+    "description" : "methanol"
+  },
+  {
+    "name" : "MEPX",
+    "type" : "CHEM_SPEC",
+    "description" : "methylhydroperoxide"
+  },
+  {
+    "name" : "MGLY",
+    "type" : "CHEM_SPEC",
+    "description" : "methylglyoxal and other aromatic products"
+  },
+  {
+    "name" : "N2O5",
+    "type" : "CHEM_SPEC",
+    "description" : "dinitrogen pentoxide"
+  },
+  {
+    "name" : "NO",
+    "type" : "CHEM_SPEC",
+    "description" : "nitric oxide"
+  },
+  {
+    "name" : "NO2",
+    "type" : "CHEM_SPEC",
+    "description" : "nitrogen dioxide"
+  },
+  {
+    "name" : "NO3",
+    "type" : "CHEM_SPEC",
+    "description" : "nitrate radical"
+  },
+  {
+    "name" : "NTR",
+    "type" : "CHEM_SPEC",
+    "description" : "organic nitrate (RNO3)"
+  },
+  {
+    "name" : "O",
+    "type" : "CHEM_SPEC",
+    "description" : "oxygen atom in the O3P electronic state"
+  },
+  {
+    "name" : "O1D",
+    "type" : "CHEM_SPEC",
+    "description" : "oxygen atom in the O1D electronic state"
+  },
+  {
+    "name" : "O3",
+    "type" : "CHEM_SPEC",
+    "description" : "ozone"
+  },
+  {
+    "name" : "OH",
+    "type" : "CHEM_SPEC",
+    "description" : "hydroxyl radical"
+  },
+  {
+    "name" : "OLE",
+    "type" : "CHEM_SPEC",
+    "description" : "terminal olefin carbon bond (R-C=C)"
+  },
+  {
+    "name" : "OPEN",
+    "type" : "CHEM_SPEC",
+    "description" : "aromatic ring opening products"
+  },
+  {
+    "name" : "PACD",
+    "type" : "CHEM_SPEC",
+    "description" : "peroxyacetic and higher peroxycarboxylic acids"
+  },
+  {
+    "name" : "PAN",
+    "type" : "CHEM_SPEC",
+    "description" : "peroxyacetyl nitrate"
+  },
+  {
+    "name" : "PANX",
+    "type" : "CHEM_SPEC",
+    "description" : "C3 and higher peroxyacyl nitrates"
+  },
+  {
+    "name" : "PAR",
+    "type" : "CHEM_SPEC",
+    "description" : "paraffin carbon bond (C-C)"
+  },
+  {
+    "name" : "PNA",
+    "type" : "CHEM_SPEC",
+    "description" : "peroxynitric acid (HNO4)"
+  },
+  {
+    "name" : "ROOH",
+    "type" : "CHEM_SPEC",
+    "description" : "higher organic peroxides"
+  },
+  {
+    "name" : "ROR",
+    "type" : "CHEM_SPEC",
+    "description" : "secondary alkoxy radical"
+  },
+  {
+    "name" : "SESQ",
+    "type" : "CHEM_SPEC",
+    "description" : "sesquiterpene"
+  },
+  {
+    "name" : "SESQRXN",
+    "type" : "CHEM_SPEC",
+    "description" : "counter for aerosol from SESQ"
+  },
+  {
+    "name" : "SO2",
+    "type" : "CHEM_SPEC",
+    "description" : "sulfur dioxide"
+  },
+  {
+    "name" : "SULF",
+    "type" : "CHEM_SPEC",
+    "description" : "sulfuric acid (gaseous)"
+  },
+  {
+    "name" : "SULRXN",
+    "type" : "CHEM_SPEC",
+    "description" : "counter for aerosol from SO2"
+  },
+  {
+    "name" : "TERP",
+    "type" : "CHEM_SPEC",
+    "description" : "terpene"
+  },
+  {
+    "name" : "TO2",
+    "type" : "CHEM_SPEC",
+    "description" : "toluene-hydroxyl radical aduct"
+  },
+  {
+    "name" : "TOL",
+    "type" : "CHEM_SPEC",
+    "description" : "toluene"
+  },
+  {
+    "name" : "TOLHRXN",
+    "type" : "CHEM_SPEC",
+    "description" : "counter for aerosol from TOL - how does this differ from TOLNRXN?"
+  },
+  {
+    "name" : "TOLNRXN",
+    "type" : "CHEM_SPEC",
+    "description" : "counter for aerosol from TOL"
+  },
+  {
+    "name" : "TOLRO2",
+    "type" : "CHEM_SPEC",
+    "description" : "first generation product from TOL"
+  },
+  {
+    "name" : "TRPRXN",
+    "type" : "CHEM_SPEC",
+    "description" : "counter for aerosol from TERP"
+  },
+  {
+    "name" : "XO2",
+    "type" : "CHEM_SPEC",
+    "description" : "NO to NO2 conversion from alkylperoxy (RO2) radical"
+  },
+  {
+    "name" : "XO2N",
+    "type" : "CHEM_SPEC",
+    "description" : "NO to organic nitrate conversion from alkylperoxy (RO2) radical"
+  },
+  {
+    "name" : "XYL",
+    "type" : "CHEM_SPEC",
+    "description" : "xylene and other polyalkyl aromatics"
+  },
+  {
+    "name" : "XYLHRXN",
+    "type" : "CHEM_SPEC",
+    "description" : "counter for aerosol from XYL - how does this differ from XYLNRXN?"
+  },
+  {
+    "name" : "XYLNRXN",
+    "type" : "CHEM_SPEC",
+    "description" : "counter for aerosol from XYL"
+  },
+  {
+    "name" : "XYLRO2",
+    "type" : "CHEM_SPEC",
+    "description" : "first generation product from XYL"
+  },
+  {
+    "name" : "N2O",
+    "type" : "CHEM_SPEC",
+    "description" : "nitrous oxide - does not participate in CB05 reactions"
+  },
+  {
+    "name" : "DUMMY",
+    "type" : "CHEM_SPEC",
+    "description" : "not sure what this is"
+  },
+  {
+    "name" : "O2",
+    "type" : "CHEM_SPEC",
+    "description" : "molecular oxygen"
+  },
+  {
+    "name" : "H2O",
+    "type" : "CHEM_SPEC",
+    "description" : "water vapor"
+  },
+  {
+    "name" : "H2",
+    "type" : "CHEM_SPEC",
+    "description" : "molecular hydrogen"
+  },
+  {
+    "name" : "M",
+    "type" : "CHEM_SPEC",
+    "description" : "third body"
+  }
+]}

--- a/src/examples/runs/atmospheric_chemistry/CB05CL_AE5/CAMP/config_cb05cl_ae5.json
+++ b/src/examples/runs/atmospheric_chemistry/CB05CL_AE5/CAMP/config_cb05cl_ae5.json
@@ -1,9 +1,9 @@
 
 {
 	"camp-files" : [
-		"/Users/odiazib/Documents/CODE/GitHub/camp/build/mechanisms_run/cb05cl_ae5/cb05cl_ae5_mechanism.json",
-		"/Users/odiazib/Documents/CODE/GitHub/camp/build/mechanisms_run/cb05cl_ae5/cb05cl_ae5_species.json",
-		"/Users/odiazib/Documents/CODE/GitHub/camp/build/test_run/chemistry/cb05cl_ae5/cb05cl_ae5_abs_tol.json",
-		"/Users/odiazib/Documents/CODE/GitHub/camp/build/test_run/chemistry/cb05cl_ae5/cb05cl_ae5_init.json"
+		"cb05cl_ae5_mechanism.json",
+		"cb05cl_ae5_species.json",
+		"cb05cl_ae5_abs_tol.json",
+		"cb05cl_ae5_init.json"
 	]
 }

--- a/src/examples/runs/atmospheric_chemistry/CB05CL_AE5/CAMP/run.sh
+++ b/src/examples/runs/atmospheric_chemistry/CB05CL_AE5/CAMP/run.sh
@@ -1,5 +1,8 @@
-camp_dir="/Users/odiazib/Documents/CODE/GitHub/camp/build"
+if [ -z "${CAMP_INSTALL_PATH}"]; then
+   echo "Set CAMP_INSTALL_PATH to run CAMP test"
+   exit 1
+fi
 mkdir out
-exec=$camp_dir/test_chemistry_cb05cl_ae5
+exec=$CAMP_INSTALL_PATH/test_chemistry_cb05cl_ae5
 echo "$exec"
 eval "$exec"

--- a/src/examples/runs/atmospheric_chemistry/CB05CL_AE5/runModel.sh
+++ b/src/examples/runs/atmospheric_chemistry/CB05CL_AE5/runModel.sh
@@ -1,4 +1,3 @@
-#TCHEM_INSTALL_PATH=${HOME}/Documents/CODE/Getz/install/tchem
 exec=$TCHEM_INSTALL_PATH/examples/TChem_AtmosphericChemistry.x
 
 run_this="$exec --chemfile=config_full_gas.yaml \


### PR DESCRIPTION
I added the CAMP inputs so that it is easier for someone to run this CAMP example to compare against TChem CB05CL_AE5. The user can now set `CAMP_INSTALL_PATH` and reproduce the results using `./run.sh`.

@odiazib please verify that these are indeed the correct files. The configuration json file had absolute file paths to inputs on your system but I was able to piece together what I thought they might be. However I want to verify that you did not alter these from their CAMP repo state to produce the results that are stored in the repo.