### PR TITLE
Fixing the runtime error 'View assignment must have compatible"

### DIFF
--- a/src/core/TChem_AerosolChemistry_CVODE_RHS_Jacobian.hpp
+++ b/src/core/TChem_AerosolChemistry_CVODE_RHS_Jacobian.hpp
@@ -45,6 +45,7 @@ struct UserData
 
   using real_type_1d_view_type = Tines::value_type_1d_view<real_type,device_type>;
   using real_type_2d_view_type = Tines::value_type_2d_view<real_type,device_type>;
+  using real_type_3d_view_type = Tines::value_type_3d_view<real_type,device_type>;
   using policy_type = typename UseThisTeamPolicy<exec_space>::type;
 
   int nbatches  = 100; // number of chemical networks
@@ -55,6 +56,10 @@ struct UserData
   real_type_1d_view_type pressure;
   real_type_2d_view_type const_tracers;
   real_type_2d_view_type fac;
+#if defined(TCHEM_ATM_ENABLE_GPU)
+  real_type_3d_view_type JacRL;
+#endif
+
   TChem::KineticModelNCAR_ConstData<device_type> kmcd;
   TChem::AerosolModel_ConstData<device_type> amcd;
 };

--- a/src/core/TChem_atm_Config.hpp.in
+++ b/src/core/TChem_atm_Config.hpp.in
@@ -22,4 +22,8 @@
 #define TCHEM_ATM_ENABLE_TPL_YAML_CPP
 #endif
 
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+#define TCHEM_ATM_ENABLE_GPU
+#endif
+
 #endif

--- a/src/examples/TChem_AerosolChemistry_CVODE_K.cpp
+++ b/src/examples/TChem_AerosolChemistry_CVODE_K.cpp
@@ -400,6 +400,10 @@ int main(int argc, char *argv[]) {
       udata.fac=fac;
       per_team_extent = problem_type::getWorkSpaceSize(kmcd,amcd)
         + number_of_equations;
+#if defined(TCHEM_ATM_ENABLE_GPU)
+    real_type_3d_view_type JacRL("JacRL", nBatch, number_of_equations, number_of_equations);
+    udata.JacRL=JacRL;
+#endif
     }
     else
     {


### PR DESCRIPTION
Fixing the runtime error `'View assignment must have compatible layouts' failed`. Sundials uses a left layout on the device, while we are using a right layout. This incompatible layout issue is producing a runtime error.