### PR TITLE
Adding additional information to the wall time files.

### DIFF
--- a/src/core/TChem_AerosolChemistry.cpp
+++ b/src/core/TChem_AerosolChemistry.cpp
@@ -42,11 +42,12 @@ namespace TChem
           const Tines::value_type_1d_view<real_type, DeviceType>& t_out,
           const Tines::value_type_1d_view<real_type, DeviceType>& dt_out,
           const Tines::value_type_2d_view<real_type, DeviceType>& state_out,
+          TChem::TeamConfOutput& team_conf_output,
           /// const data from kinetic model
           const KineticModelNCAR_ConstData<DeviceType>& kmcd,
           const AerosolModel_ConstData<DeviceType>& amcd
           ) {
-    Kokkos::Profiling::pushRegion(profile_name);
+
     using policy_type = PolicyType;
 
     using real_type_0d_view_type = Tines::value_type_0d_view<real_type, DeviceType>;
@@ -56,135 +57,137 @@ namespace TChem
     using problem_type = TChem::Impl::AerosolChemistry_Problem<real_type,DeviceType>;
     const ordinal_type level = 1;
     const ordinal_type per_team_extent = AerosolChemistry::getWorkSpaceSize(kmcd,amcd);
-    Kokkos::parallel_for
-      (profile_name,
-       policy,
-       KOKKOS_LAMBDA(const typename policy_type::member_type& member) {
-  const ordinal_type i = member.league_rank();
 
-  const auto tadv_at_i = tadv(i);
-  const real_type t_end = tadv_at_i._tend;
-  const real_type_0d_view_type t_out_at_i = Kokkos::subview(t_out, i);
-  if (t_out_at_i() < t_end) {
-    const real_type_1d_view_type state_at_i =
-        Kokkos::subview(state, i, Kokkos::ALL());
+    auto ivp_lambda =  KOKKOS_LAMBDA(const typename policy_type::member_type& member) {
+      const ordinal_type i = member.league_rank();
 
-      const real_type_1d_view_type number_conc_at_i =
-        Kokkos::subview(number_conc, i, Kokkos::ALL());
+      const auto tadv_at_i = tadv(i);
+      const real_type t_end = tadv_at_i._tend;
+      const real_type_0d_view_type t_out_at_i = Kokkos::subview(t_out, i);
+      if (t_out_at_i() < t_end) {
+        const real_type_1d_view_type state_at_i =
+            Kokkos::subview(state, i, Kokkos::ALL());
 
-      const real_type_1d_view_type state_out_at_i =
-        Kokkos::subview(state_out, i, Kokkos::ALL());
-      const real_type_1d_view_type fac_at_i =
-        Kokkos::subview(fac, i, Kokkos::ALL());
-      const real_type_0d_view_type dt_out_at_i = Kokkos::subview(dt_out, i);
-      Scratch<real_type_1d_view_type> work(member.team_scratch(level),
-                                       per_team_extent);
-      auto wptr = work.data();
-      const ordinal_type total_n_species = kmcd.nSpec + amcd.nParticles*amcd.nSpec;
-      Impl::StateVector<real_type_1d_view_type> sv_at_i(total_n_species, state_at_i);
-      Impl::StateVector<real_type_1d_view_type> sv_out_at_i(total_n_species,
-                                                        state_out_at_i);
-      TCHEM_CHECK_ERROR(!sv_at_i.isValid(),
-                        "Error: input state vector is not valid");
-      TCHEM_CHECK_ERROR(!sv_out_at_i.isValid(),
-                        "Error: input state vector is not valid");
-    {
-      const ordinal_type jacobian_interval =
-          tadv_at_i._jacobian_interval;
-      const ordinal_type max_num_newton_iterations =
-          tadv_at_i._max_num_newton_iterations;
-      const ordinal_type max_num_time_iterations = tadv_at_i._num_time_iterations_per_interval;
-      const real_type
-        dt_in = tadv_at_i._dt,
-        dt_min = tadv_at_i._dtmin,
-        dt_max = tadv_at_i._dtmax;
-      const real_type t_beg = tadv_at_i._tbeg;
+          const real_type_1d_view_type number_conc_at_i =
+            Kokkos::subview(number_conc, i, Kokkos::ALL());
 
-      const real_type temperature = sv_at_i.Temperature();
-      const real_type pressure = sv_at_i.Pressure();
-      const real_type density = sv_at_i.Density();
-      const real_type_1d_view_type Ys = sv_at_i.MassFractions();
-      const ordinal_type n_active_gas_species = kmcd.nSpec - kmcd.nConstSpec;
-      const real_type_1d_view_type activeYs = Kokkos::subview(Ys,
-          range_type(0, n_active_gas_species));
-      const real_type_1d_view_type constYs = Kokkos::subview(Ys,
-          range_type(n_active_gas_species, kmcd.nSpec));
-      const real_type_1d_view_type partYs = Kokkos::subview(Ys,
-          range_type(kmcd.nSpec, total_n_species));
+          const real_type_1d_view_type state_out_at_i =
+            Kokkos::subview(state_out, i, Kokkos::ALL());
+          const real_type_1d_view_type fac_at_i =
+            Kokkos::subview(fac, i, Kokkos::ALL());
+          const real_type_0d_view_type dt_out_at_i = Kokkos::subview(dt_out, i);
+          Scratch<real_type_1d_view_type> work(member.team_scratch(level),
+                                           per_team_extent);
+          auto wptr = work.data();
+          const ordinal_type total_n_species = kmcd.nSpec + amcd.nParticles*amcd.nSpec;
+          Impl::StateVector<real_type_1d_view_type> sv_at_i(total_n_species, state_at_i);
+          Impl::StateVector<real_type_1d_view_type> sv_out_at_i(total_n_species,
+                                                            state_out_at_i);
+          TCHEM_CHECK_ERROR(!sv_at_i.isValid(),
+                            "Error: input state vector is not valid");
+          TCHEM_CHECK_ERROR(!sv_out_at_i.isValid(),
+                            "Error: input state vector is not valid");
+        {
+          const ordinal_type jacobian_interval =
+              tadv_at_i._jacobian_interval;
+          const ordinal_type max_num_newton_iterations =
+              tadv_at_i._max_num_newton_iterations;
+          const ordinal_type max_num_time_iterations = tadv_at_i._num_time_iterations_per_interval;
+          const real_type
+            dt_in = tadv_at_i._dt,
+            dt_min = tadv_at_i._dtmin,
+            dt_max = tadv_at_i._dtmax;
+          const real_type t_beg = tadv_at_i._tbeg;
 
-      const real_type_0d_view_type temperature_out(sv_out_at_i.TemperaturePtr());
-      const real_type_0d_view_type pressure_out(sv_out_at_i.PressurePtr());
-      const real_type_1d_view_type Ys_out = sv_out_at_i.MassFractions();
-      const real_type_0d_view_type density_out(sv_out_at_i.DensityPtr());
+          const real_type temperature = sv_at_i.Temperature();
+          const real_type pressure = sv_at_i.Pressure();
+          const real_type density = sv_at_i.Density();
+          const real_type_1d_view_type Ys = sv_at_i.MassFractions();
+          const ordinal_type n_active_gas_species = kmcd.nSpec - kmcd.nConstSpec;
+          const real_type_1d_view_type activeYs = Kokkos::subview(Ys,
+              range_type(0, n_active_gas_species));
+          const real_type_1d_view_type constYs = Kokkos::subview(Ys,
+              range_type(n_active_gas_species, kmcd.nSpec));
+          const real_type_1d_view_type partYs = Kokkos::subview(Ys,
+              range_type(kmcd.nSpec, total_n_species));
 
-      const ordinal_type m = problem_type::getNumberOfTimeODEs(kmcd,amcd);     
-      /// temporal var
-      real_type_1d_view_type vals(wptr, m);
-      wptr += m;
-      const real_type_1d_view_type ww(wptr, work.extent(0)-m);
-      wptr += (work.extent(0)-m);
+          const real_type_0d_view_type temperature_out(sv_out_at_i.TemperaturePtr());
+          const real_type_0d_view_type pressure_out(sv_out_at_i.PressurePtr());
+          const real_type_1d_view_type Ys_out = sv_out_at_i.MassFractions();
+          const real_type_0d_view_type density_out(sv_out_at_i.DensityPtr());
 
-      /// error check
-      const ordinal_type workspace_used(wptr - work.data()), workspace_extent(work.extent(0));
-      if (workspace_used > workspace_extent) {
-        Kokkos::abort("Error Ignition ZeroD Sacado : workspace used is larger than it is provided\n");
+          const ordinal_type m = problem_type::getNumberOfTimeODEs(kmcd,amcd);
+          /// temporal var
+          real_type_1d_view_type vals(wptr, m);
+          wptr += m;
+          const real_type_1d_view_type ww(wptr, work.extent(0)-m);
+          wptr += (work.extent(0)-m);
+
+          /// error check
+          const ordinal_type workspace_used(wptr - work.data()), workspace_extent(work.extent(0));
+          if (workspace_used > workspace_extent) {
+            Kokkos::abort("Error Ignition ZeroD Sacado : workspace used is larger than it is provided\n");
+          }
+          // active gas species
+          for (ordinal_type i=0;i<n_active_gas_species;++i){
+            vals(i) = activeYs(i);
+          }
+
+          for (ordinal_type i=n_active_gas_species;i<total_n_species- kmcd.nConstSpec;++i)
+          {
+            vals(i) = partYs(i-n_active_gas_species);
+          }
+
+          using aerosol_chemistry_type =
+          Impl::AerosolChemistry<ValueType,DeviceType>;
+
+          aerosol_chemistry_type::team_invoke(member,
+                                              jacobian_interval,
+                                              max_num_newton_iterations,
+                                              max_num_time_iterations,
+                                              tol_newton,
+                                              tol_time,
+                                              fac_at_i,
+                                              dt_in,
+                                              dt_min,
+                                              dt_max,
+                                              t_beg,
+                                              t_end,
+                                              temperature,
+                                              pressure,
+                                              number_conc_at_i,
+                                              constYs,
+                                              vals,
+                                              t_out_at_i,
+                                              dt_out_at_i,
+                                              vals,
+                                              ww,
+                                              kmcd,
+                                              amcd);
+
+          // active gas species
+          for (ordinal_type i=0;i<n_active_gas_species;++i)
+            Ys_out(i) = vals(i);
+          // particle species
+          // Ys_out also contains invariant species
+          // total_n_species includes invariant species
+          for (ordinal_type i=n_active_gas_species;i<total_n_species-kmcd.nConstSpec;++i)
+            Ys_out(i+kmcd.nConstSpec)=vals(i);
+
+          temperature_out() =temperature;
+
+        }
       }
-      // active gas species
-      for (ordinal_type i=0;i<n_active_gas_species;++i){
-        vals(i) = activeYs(i);
-      }
-
-      for (ordinal_type i=n_active_gas_species;i<total_n_species- kmcd.nConstSpec;++i)
-      {
-        vals(i) = partYs(i-n_active_gas_species);
-      }
-
-      using aerosol_chemistry_type =
-      Impl::AerosolChemistry<ValueType,DeviceType>;
-
-      aerosol_chemistry_type::team_invoke(member,
-                                          jacobian_interval,
-                                          max_num_newton_iterations,
-                                          max_num_time_iterations,
-                                          tol_newton,
-                                          tol_time,
-                                          fac_at_i,
-                                          dt_in,
-                                          dt_min,
-                                          dt_max,
-                                          t_beg,
-                                          t_end,
-                                          temperature,
-                                          pressure,
-                                          number_conc_at_i,
-                                          constYs,
-                                          vals,
-                                          t_out_at_i,
-                                          dt_out_at_i,
-                                          vals,
-                                          ww,
-                                          kmcd,
-                                          amcd);
-
-      // active gas species
-      for (ordinal_type i=0;i<n_active_gas_species;++i)
-        Ys_out(i) = vals(i);
-      // particle species
-      // Ys_out also contains invariant species
-      // total_n_species includes invariant species
-      for (ordinal_type i=n_active_gas_species;i<total_n_species-kmcd.nConstSpec;++i)
-        Ys_out(i+kmcd.nConstSpec)=vals(i);
-
-      temperature_out() =temperature;
-
-    }
-  }
-      });
+    };
+    Kokkos::Profiling::pushRegion(profile_name);
+    Kokkos::parallel_for(profile_name,policy,ivp_lambda);
     Kokkos::Profiling::popRegion();
+
+    team_conf_output.team_size_recommended = policy.team_size_recommended(
+      ivp_lambda, Kokkos::ParallelForTag());
+    team_conf_output.team_size_max = policy.team_size_max(
+      ivp_lambda, Kokkos::ParallelForTag());
   }
-
-
-
 #define TCHEM_RUN_AEROSOL_CHEMISTRY()     \
   AerosolChemistry_TemplateRun(          \
           profile_name,       \
@@ -199,6 +202,7 @@ namespace TChem
           t_out,        \
           dt_out,       \
           state_out,    \
+          team_conf_output, \
           kmcd,        \
           amcd )
 
@@ -216,6 +220,7 @@ namespace TChem
            const real_type_1d_view_host& t_out,
            const real_type_1d_view_host& dt_out,
            const real_type_2d_view_host& state_out,
+           TeamConfOutput& team_conf_output,
            /// const data from kinetic model
            const KineticModelNCAR_ConstData<interf_host_device_type>& kmcd,
            const AerosolModel_ConstData<interf_host_device_type>& amcd
@@ -240,6 +245,7 @@ namespace TChem
            const real_type_1d_view& t_out,
            const real_type_1d_view& dt_out,
            const real_type_2d_view& state_out,
+           TeamConfOutput& team_conf_output,
            /// const data from kinetic model
            const KineticModelNCAR_ConstData<device_type>& kmcd,
            const AerosolModel_ConstData<device_type>& amcd

--- a/src/core/TChem_AerosolChemistry.hpp
+++ b/src/core/TChem_AerosolChemistry.hpp
@@ -29,6 +29,12 @@ Sandia National Laboratories, New Mexico/Livermore, NM/CA, USA
 
 namespace TChem {
 
+struct TeamConfOutput
+{
+   ordinal_type team_size_recommended{-1};
+   ordinal_type team_size_max{-1};
+};
+
 struct AerosolChemistry
 {
   using host_device_type = typename Tines::UseThisDevice<host_exec_space>::type;
@@ -70,6 +76,7 @@ struct AerosolChemistry
            const real_type_1d_view_host& t_out,
            const real_type_1d_view_host& dt_out,
            const real_type_2d_view_host& state_out,
+           TeamConfOutput& team_conf_output,
            /// const data from kinetic model
            const KineticModelNCAR_ConstData<interf_host_device_type>& kmcd,
            const AerosolModel_ConstData<interf_host_device_type>& amcd
@@ -89,6 +96,7 @@ struct AerosolChemistry
            const real_type_1d_view& t_out,
            const real_type_1d_view& dt_out,
            const real_type_2d_view& state_out,
+           TeamConfOutput& team_conf_output,
            /// const data from kinetic model
            const KineticModelNCAR_ConstData<device_type>& kmcd,
            const AerosolModel_ConstData<device_type>& amcd

--- a/src/core/TChem_AerosolChemistry_CVODE_RHS_Jacobian.cpp
+++ b/src/core/TChem_AerosolChemistry_CVODE_RHS_Jacobian.cpp
@@ -39,7 +39,6 @@ int AerosolChemistry_CVODE_K::f(sunrealtype t, N_Vector y, N_Vector ydot, void* 
   const auto pressure= udata->pressure;
   const auto const_tracers= udata->const_tracers;
 
-  real_type_2d_view_type y2d(N_VGetDeviceArrayPointer(y), nbatches, batchSize);
   real_type_2d_view_type vals(N_VGetDeviceArrayPointer(y), nbatches, batchSize);
   real_type_2d_view_type rhs(N_VGetDeviceArrayPointer(ydot), nbatches, batchSize);
 
@@ -48,33 +47,18 @@ int AerosolChemistry_CVODE_K::f(sunrealtype t, N_Vector y, N_Vector ydot, void* 
   const ordinal_type per_team_extent
          = TChem::Impl::Aerosol_RHS<real_type, device_type>::getWorkSpaceSize(kmcd, amcd);
   const std::string profile_name = "TChem::AerosolChemistry::RHS_evaluation";
-  Kokkos::Profiling::pushRegion(profile_name);
-  Kokkos::parallel_for
-  (profile_name,
-       policy,
-       KOKKOS_LAMBDA(const typename policy_type::member_type& member) {
 
-        const ordinal_type i = member.league_rank();
-        const ordinal_type m = problem_type::getNumberOfTimeODEs(kmcd,amcd);
-        const real_type_1d_view_type rhs_at_i =
-        Kokkos::subview(rhs, i, Kokkos::ALL());
-        const real_type_1d_view_type vals_at_i =
-        Kokkos::subview(vals, i, Kokkos::ALL());
-        const real_type_1d_view_type number_conc_at_i =
-        Kokkos::subview(num_concentration, i, Kokkos::ALL());
-        TChem::Scratch<real_type_1d_view_type> work(member.team_scratch(level),
-                                       per_team_extent);
-        const real_type_1d_view_type constYs  = Kokkos::subview(const_tracers, i, Kokkos::ALL());
-        auto wptr = work.data();
-        auto pw = real_type_1d_view_type(wptr, per_team_extent);
-        wptr +=per_team_extent;
-        TChem::Impl::Aerosol_RHS<real_type, device_type>
-        ::team_invoke(member,
-        temperature(i), pressure(i), number_conc_at_i, vals_at_i, constYs,
-        rhs_at_i, pw, kmcd, amcd);
-      });
+  TChemAerosolChemistryRHS rhs_tchem(rhs, vals, num_concentration,
+     const_tracers, temperature, pressure, kmcd, amcd);
+
+  Kokkos::Profiling::pushRegion(profile_name);
+  Kokkos::parallel_for(profile_name, policy, rhs_tchem);
   Kokkos::Profiling::popRegion();
 
+  udata->team_size_recommended_rhs = policy.team_size_recommended(
+    rhs_tchem, Kokkos::ParallelForTag());
+  udata->team_size_max_rhs = policy.team_size_max(
+    rhs_tchem, Kokkos::ParallelForTag());
 
  return 0;
 }
@@ -108,61 +92,64 @@ int AerosolChemistry_CVODE_K::Jac(sunrealtype t, N_Vector y, N_Vector fy, SUNMat
   const ordinal_type per_team_extent = problem_type::getWorkSpaceSize(kmcd,amcd)
     + number_of_equations;
   const std::string profile_name = "TChem::AerosolChemistry::Jacobian_evaluation";
-  Kokkos::Profiling::pushRegion(profile_name);
-  Kokkos::parallel_for
-  (profile_name,
-       policy,
-       KOKKOS_LAMBDA(const typename policy_type::member_type& member) {
+  auto jac_lambda =        KOKKOS_LAMBDA(const typename policy_type::member_type& member) {
 
-        const ordinal_type i = member.league_rank();
+    const ordinal_type i = member.league_rank();
 
-        const ordinal_type m = problem_type::getNumberOfTimeODEs(kmcd,amcd);
-        const real_type_1d_view_type vals_at_i =
-        Kokkos::subview(vals, i, Kokkos::ALL());
+    const ordinal_type m = problem_type::getNumberOfTimeODEs(kmcd,amcd);
+    const real_type_1d_view_type vals_at_i =
+    Kokkos::subview(vals, i, Kokkos::ALL());
 
-        const real_type_1d_view_type fac_at_i =
-        Kokkos::subview(fac, i, Kokkos::ALL());
+    const real_type_1d_view_type fac_at_i =
+    Kokkos::subview(fac, i, Kokkos::ALL());
 
-        const real_type_2d_view_type jacobian_at_i =
+    const real_type_2d_view_type jacobian_at_i =
 #if defined(TCHEM_ATM_ENABLE_GPU)
-        Kokkos::subview(JacRL, i, Kokkos::ALL(), Kokkos::ALL());
+    Kokkos::subview(JacRL, i, Kokkos::ALL(), Kokkos::ALL());
 #else
-        Kokkos::subview(J_data, i, Kokkos::ALL(), Kokkos::ALL());
+    Kokkos::subview(J_data, i, Kokkos::ALL(), Kokkos::ALL());
 #endif
 
-        const real_type_1d_view_type number_conc_at_i =
-        Kokkos::subview(num_concentration, i, Kokkos::ALL());
+    const real_type_1d_view_type number_conc_at_i =
+    Kokkos::subview(num_concentration, i, Kokkos::ALL());
 
-        TChem::Scratch<real_type_1d_view_type> work(member.team_scratch(level),
-                                       per_team_extent);
+    TChem::Scratch<real_type_1d_view_type> work(member.team_scratch(level),
+                                   per_team_extent);
 
-        auto wptr = work.data();
+    auto wptr = work.data();
 
-        const real_type_1d_view_type constYs  = Kokkos::subview(const_tracers, i, Kokkos::ALL());
+    const real_type_1d_view_type constYs  = Kokkos::subview(const_tracers, i, Kokkos::ALL());
 
-        const ordinal_type problem_workspace_size = problem_type::getWorkSpaceSize(kmcd,amcd);
-        auto pw = real_type_1d_view_type(wptr, problem_workspace_size);
-        wptr +=problem_workspace_size;
-        problem_type problem;
-        problem._kmcd = kmcd;
-        problem._amcd = amcd;
-        /// initialize problem
-        problem._fac = fac_at_i;
-        problem._work = pw;
-        problem._temperature= temperature(i);
-        problem._pressure =pressure(i);
-        problem._const_concentration= constYs;
-        problem._number_conc =number_conc_at_i;
-        problem.computeNumericalJacobian(member,vals_at_i,jacobian_at_i);
+    const ordinal_type problem_workspace_size = problem_type::getWorkSpaceSize(kmcd,amcd);
+    auto pw = real_type_1d_view_type(wptr, problem_workspace_size);
+    wptr +=problem_workspace_size;
+    problem_type problem;
+    problem._kmcd = kmcd;
+    problem._amcd = amcd;
+    /// initialize problem
+    problem._fac = fac_at_i;
+    problem._work = pw;
+    problem._temperature= temperature(i);
+    problem._pressure =pressure(i);
+    problem._const_concentration= constYs;
+    problem._number_conc =number_conc_at_i;
+    problem.computeNumericalJacobian(member,vals_at_i,jacobian_at_i);
 #if defined(TCHEM_ATM_ENABLE_GPU)
-        //NOTE: Sundials uses a left layout on the device, while we are using a right layout.
-        // This incompatible layouts is producing a runtime error.
-        for (int k=0;k<batchSize;++k)
-          for (int j=0;j<batchSize;++j)
-           J_data(i, k, j) = jacobian_at_i(k,j);
+    //NOTE: Sundials uses a left layout on the device, while we are using a right layout.
+    // This incompatible layouts is producing a runtime error.
+    for (int k=0;k<batchSize;++k)
+      for (int j=0;j<batchSize;++j)
+       J_data(i, k, j) = jacobian_at_i(k,j);
 #endif
-        });
-       Kokkos::Profiling::popRegion();
+    };
+  Kokkos::Profiling::pushRegion(profile_name);
+  Kokkos::parallel_for(profile_name, policy, jac_lambda);
+  Kokkos::Profiling::popRegion();
+
+  udata->team_size_recommended_jac = policy.team_size_recommended(
+    jac_lambda, Kokkos::ParallelForTag());
+  udata->team_size_max_jac = policy.team_size_max(
+    jac_lambda, Kokkos::ParallelForTag());
 
   return 0;
 

--- a/src/core/TChem_AerosolChemistry_CVODE_RHS_Jacobian.cpp
+++ b/src/core/TChem_AerosolChemistry_CVODE_RHS_Jacobian.cpp
@@ -73,6 +73,7 @@ int AerosolChemistry_CVODE_K::f(sunrealtype t, N_Vector y, N_Vector ydot, void* 
         temperature(i), pressure(i), number_conc_at_i, vals_at_i, constYs,
         rhs_at_i, pw, kmcd, amcd);
       });
+  Kokkos::Profiling::popRegion();
 
 
  return 0;
@@ -160,8 +161,8 @@ int AerosolChemistry_CVODE_K::Jac(sunrealtype t, N_Vector y, N_Vector fy, SUNMat
           for (int j=0;j<batchSize;++j)
            J_data(i, k, j) = jacobian_at_i(k,j);
 #endif
-      });
-
+        });
+       Kokkos::Profiling::popRegion();
 
   return 0;
 

--- a/src/core/TChem_AerosolChemistry_CVODE_RHS_Jacobian.hpp
+++ b/src/core/TChem_AerosolChemistry_CVODE_RHS_Jacobian.hpp
@@ -38,6 +38,73 @@ Sandia National Laboratories, New Mexico/Livermore, NM/CA, USA
 
 namespace TChem {
 
+
+struct TChemAerosolChemistryRHS {
+
+  using device_type      = typename Tines::UseThisDevice<exec_space>::type;
+  using problem_type = TChem::Impl::AerosolChemistry_Problem<real_type,device_type>;
+  using policy_type = typename UseThisTeamPolicy<exec_space>::type;
+  using real_type_1d_view_type = Tines::value_type_1d_view<real_type,device_type>;
+  using real_type_2d_view_type = Tines::value_type_2d_view<real_type,device_type>;
+
+  real_type_2d_view_type rhs;
+  real_type_2d_view_type vals;
+  real_type_2d_view_type num_concentration;
+  real_type_2d_view_type const_tracers;
+  real_type_1d_view_type temperature;
+  real_type_1d_view_type pressure;
+  KineticModelNCAR_ConstData<device_type> kmcd;
+  AerosolModel_ConstData<device_type> amcd;
+  ordinal_type level;
+  ordinal_type per_team_extent;
+  ordinal_type m;
+
+
+  TChemAerosolChemistryRHS(const real_type_2d_view_type& rhs_in,
+           const real_type_2d_view_type& vals_in,
+           const real_type_2d_view_type& num_concentration_in,
+           const real_type_2d_view_type& const_tracers_in,
+           const real_type_1d_view_type& temperature_in,
+           const real_type_1d_view_type& pressure_in,
+           const KineticModelNCAR_ConstData<device_type>& kmcd_in,
+           const AerosolModel_ConstData<device_type>& amcd_in)
+   : rhs(rhs_in),
+     vals(vals_in),
+     num_concentration(num_concentration_in),
+     const_tracers(const_tracers_in),
+     temperature(temperature_in),
+     pressure(pressure_in),
+     kmcd(kmcd_in),
+     amcd(amcd_in)
+     {
+      level = 1;
+      per_team_extent
+         = Impl::Aerosol_RHS<real_type, device_type>::getWorkSpaceSize(kmcd, amcd);
+      m = problem_type::getNumberOfTimeODEs(kmcd,amcd);
+     }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const typename policy_type::member_type& member) const {
+    const ordinal_type i = member.league_rank();
+
+    const real_type_1d_view_type rhs_at_i =
+    Kokkos::subview(rhs, i, Kokkos::ALL());
+    const real_type_1d_view_type vals_at_i =
+    Kokkos::subview(vals, i, Kokkos::ALL());
+    const real_type_1d_view_type number_conc_at_i =
+    Kokkos::subview(num_concentration, i, Kokkos::ALL());
+    TChem::Scratch<real_type_1d_view_type> work(member.team_scratch(level),
+                                   per_team_extent);
+    const real_type_1d_view_type constYs  = Kokkos::subview(const_tracers, i, Kokkos::ALL());
+    auto wptr = work.data();
+    auto pw = real_type_1d_view_type(wptr, per_team_extent);
+    wptr +=per_team_extent;
+    TChem::Impl::Aerosol_RHS<real_type, device_type>
+    ::team_invoke(member,
+    temperature(i), pressure(i), number_conc_at_i, vals_at_i, constYs,
+    rhs_at_i, pw, kmcd, amcd);
+  }
+};
 struct UserData
 {
   using host_device_type = typename Tines::UseThisDevice<host_exec_space>::type;
@@ -59,6 +126,10 @@ struct UserData
 #if defined(TCHEM_ATM_ENABLE_GPU)
   real_type_3d_view_type JacRL;
 #endif
+  ordinal_type team_size_recommended_rhs{-1};
+  ordinal_type team_size_recommended_jac{-1};
+  ordinal_type team_size_max_rhs{-1};
+  ordinal_type team_size_max_jac{-1};
 
   TChem::KineticModelNCAR_ConstData<device_type> kmcd;
   TChem::AerosolModel_ConstData<device_type> amcd;

--- a/src/core/TChem_AerosolChemistry_CVODE_RHS_Jacobian.hpp
+++ b/src/core/TChem_AerosolChemistry_CVODE_RHS_Jacobian.hpp
@@ -45,6 +45,7 @@ struct UserData
 
   using real_type_1d_view_type = Tines::value_type_1d_view<real_type,device_type>;
   using real_type_2d_view_type = Tines::value_type_2d_view<real_type,device_type>;
+  using real_type_3d_view_type = Tines::value_type_3d_view<real_type,device_type>;
   using policy_type = typename UseThisTeamPolicy<exec_space>::type;
 
   int nbatches  = 100; // number of chemical networks
@@ -55,6 +56,10 @@ struct UserData
   real_type_1d_view_type pressure;
   real_type_2d_view_type const_tracers;
   real_type_2d_view_type fac;
+#if defined(TCHEM_ATM_ENABLE_GPU)
+  real_type_3d_view_type JacRL;
+#endif
+
   TChem::KineticModelNCAR_ConstData<device_type> kmcd;
   TChem::AerosolModel_ConstData<device_type> amcd;
 };

--- a/src/core/TChem_atm_Config.hpp.in
+++ b/src/core/TChem_atm_Config.hpp.in
@@ -22,4 +22,8 @@
 #define TCHEM_ATM_ENABLE_TPL_YAML_CPP
 #endif
 
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+#define TCHEM_ATM_ENABLE_GPU
+#endif
+
 #endif

--- a/src/examples/TChem_AerosolChemistry_CVODE_K.cpp
+++ b/src/examples/TChem_AerosolChemistry_CVODE_K.cpp
@@ -400,6 +400,10 @@ int main(int argc, char *argv[]) {
       udata.fac=fac;
       per_team_extent = problem_type::getWorkSpaceSize(kmcd,amcd)
         + number_of_equations;
+#if defined(TCHEM_ATM_ENABLE_GPU)
+    real_type_3d_view_type JacRL("JacRL", nBatch, number_of_equations, number_of_equations);
+    udata.JacRL=JacRL;
+#endif
     }
     else
     {

--- a/src/examples/TChem_AerosolChemistry_CVODE_K.cpp
+++ b/src/examples/TChem_AerosolChemistry_CVODE_K.cpp
@@ -452,7 +452,7 @@ int main(int argc, char *argv[]) {
     const auto const_tracers_host =
     Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),const_tracers);
     if (write_time_profiles) {
-    writeState(-1, tout, dTout,
+    writeState(-1, tbeg, dTout,
      density_host, pressure_host, temperature_host,
      const_tracers_host, y2d_h, n_active_gas_species, fout);
     }
@@ -463,7 +463,7 @@ int main(int argc, char *argv[]) {
     // Loop over output times
     Kokkos::Timer timer;
     int iout = 0;
-    for (iout = 0; iout < Nt; iout++)
+    for (iout = 0; iout < Nt && tout <= tend * 0.9999; iout++)
     {
       // Advance in time
       timer.reset();
@@ -478,14 +478,14 @@ int main(int argc, char *argv[]) {
       sundials::kokkos::CopyFromDevice(y);
       Kokkos::fence();
 
-      tout += dTout;
-      tout = (tout > Tf) ? Tf : tout;
       if (write_time_profiles) {
       writeState(iout, tout, dTout,
        density_host, pressure_host, temperature_host,
        const_tracers_host, y2d_h,
         n_active_gas_species, fout);
       }
+      tout += dTout;
+      tout = (tout > Tf) ? Tf : tout;
     }
 
    fprintf(fout_times, "%s: %d, \n", "\"number_of_time_iters\"", iout);


### PR DESCRIPTION
I have added the `Kokkos Settings` section with additional information on team and vector sizes. I believe this information will help describe the results in our paper. For the Sundials experiments, I have added the `Sundials Final Statistics` section. Note that to determine the team size employed by `Kokkos:AUTO`, I need to refactor the main kernels of `RHS` and `Jacobian` evaluation to use either lambdas or functors.