### PR TITLE
TChem: Fixing compilation error in HIP.

### DIFF
--- a/src/unit-tests/TChem_Test_MOSAIC.hpp
+++ b/src/unit-tests/TChem_Test_MOSAIC.hpp
@@ -9,31 +9,11 @@ namespace Test {
 void static MOSAIC_Test() {
 
     using device_type = typename Tines::UseThisDevice<TChem::exec_space>::type;
-    using ordinal_type = TChem::ordinal_type;
-    using real_type = TChem::real_type;
-    using real_type_1d_view = TChem::real_type_1d_view;
-    using real_type_2d_view = TChem::real_type_2d_view;
-    using real_type_2d_view_host = TChem::real_type_2d_view_host;
-
-    std::string profile_name ="Verification_test_MTEM_compute_log_gamZ";
-    using policy_type =
-          typename TChem::UseThisTeamPolicy<TChem::exec_space>::type;
-    const auto exec_space_instance = TChem::exec_space();
     const auto host_exec_space = TChem::host_exec_space();
-    policy_type policy(exec_space_instance, 1, Kokkos::AUTO());
-
     const auto mmd = TChem::Impl::MosaicModelData<device_type>();
-
-    // Check this routines on GPUs.
-     Kokkos::parallel_for(
-    profile_name,
-    policy,
-    KOKKOS_LAMBDA(const typename policy_type::member_type& member) {
-
     auto b_mtem = mmd.b_mtem.template view<device_type>();
-
-    EXPECT_TRUE(b_mtem(0,mmd.jnh4so4,mmd.jnh4hso4) == -4.13219);
-    });
+    const auto b_mtem_h = Kokkos::create_mirror_view_and_copy(host_exec_space, b_mtem);
+    EXPECT_TRUE(b_mtem_h(0,mmd.jnh4so4,mmd.jnh4hso4) == -4.13219);
 }
 
 }// namespace Test


### PR DESCRIPTION
I am getting a compilation error because EXPECT_TRUE cannot be invoked inside a GPU kernel in HIP. I believe we do not see this error in CUDA.