### PR TITLE
Fix JSON syntax when running only Jacobian

### DIFF
--- a/src/examples/TChem_AerosolChemistry_RHSs.cpp
+++ b/src/examples/TChem_AerosolChemistry_RHSs.cpp
@@ -200,10 +200,10 @@ int main(int argc, char *argv[]) {
 
     Kokkos::Timer timer;
     FILE *fout_times = fopen(outputFileTimes.c_str(), "w");
+    fprintf(fout_times, "{\n");
 
     if (do_rhs){
       printf("..evaluating RHS\n");
-      fprintf(fout_times, "{\n");
       fprintf(fout_times, " \"Aerosol RHSs\": \n {\n");
       const ordinal_type level = 1;
       const std::string profile_name = "TChem::AerosolChemistry::RHS_evaluation";


### PR DESCRIPTION
JSON open bracket was placed inside conditional block for RHS evaluation so when running only Jacobian, the open bracket would not be included in output resulting in incorrect JSON syntax


```json
 "Aerosol Numerical Jacobian": 
 {
"wall_time": 1.35988070000000e-02, 
"wall_time_per_sample": 1.35988070000000e-02, 
"number_of_samples": 1 
} 
 }
```