### PR TITLE
Fix illegal memory access in CVODE-K

### DIFF
--- a/src/core/TChem_AerosolChemistry_CVODE_RHS_Jacobian.hpp
+++ b/src/core/TChem_AerosolChemistry_CVODE_RHS_Jacobian.hpp
@@ -106,8 +106,10 @@ struct TChemAerosolChemistryRHS {
     auto pw = real_type_1d_view_type(wptr, per_team_extent);
     wptr +=per_team_extent;
     // Resolve the per-batch sentinel: -1 means track all particles.
+    // Check unallocated or -1 (default, all particles in a system)
     const ordinal_type n_part_i =
-        n_particles_track(i) < 0 ? amcd.nParticles : n_particles_track(i);
+        (n_particles_track.span() == 0 || n_particles_track(i) < 0) 
+        ? amcd.nParticles : n_particles_track(i);
     TChem::Impl::Aerosol_RHS<real_type, device_type>
     ::team_invoke(member,
     temperature(i), pressure(i), number_conc_at_i, vals_at_i, constYs,

--- a/src/examples/TChem_AerosolChemistry_CVODE_K.cpp
+++ b/src/examples/TChem_AerosolChemistry_CVODE_K.cpp
@@ -282,6 +282,11 @@ int main(int argc, char *argv[]) {
     udata.batchSize=number_of_equations;
     udata.kmcd=kmcd;
     udata.amcd=amcd;
+
+    ordinal_type_type_1d_view_type n_particles_track("n_particles_track", nBatch);
+    Kokkos::deep_copy(n_particles_track, -1);
+    udata.n_particles_track = n_particles_track;
+    
     // Create vector with the initial condition
     const sunrealtype T0 = SUN_RCONST(tbeg);
 

--- a/src/examples/TChem_AerosolChemistry_CVODE_K.cpp
+++ b/src/examples/TChem_AerosolChemistry_CVODE_K.cpp
@@ -283,9 +283,6 @@ int main(int argc, char *argv[]) {
     udata.kmcd=kmcd;
     udata.amcd=amcd;
 
-    ordinal_type_type_1d_view_type n_particles_track("n_particles_track", nBatch);
-    Kokkos::deep_copy(n_particles_track, -1);
-    udata.n_particles_track = n_particles_track;
     
     // Create vector with the initial condition
     const sunrealtype T0 = SUN_RCONST(tbeg);


### PR DESCRIPTION
`n_particles_track` is never defined in the CVODE-K driver, so when `TChemAerosolChemistryRHS::operator()` is called, the `n_particles_track` access triggers an illegal memory access. 