### PR TITLE
Change default n_particles_track to -1

### DIFF
--- a/src/core/TChem_Driver.cpp
+++ b/src/core/TChem_Driver.cpp
@@ -516,6 +516,7 @@ void TChem::Driver::setNParticlesTrack(ordinal_type n, ordinal_type i_batch) {
   }
   if (_n_particles_track.span() == 0) {
     _n_particles_track = ordinal_type_1d_view_host("n_particles_track", _nBatch);
+    Kokkos::deep_copy(_n_particles_track, -1);
   }
   _n_particles_track(i_batch) = n;
 }


### PR DESCRIPTION
Looking at #163, I noticed Kokkos was setting the number of particles to track array to 0. However, it should be set to -1, indicating that the user has yet manually set the value and the code will default to solving the maximum number of particles. 

Defaulting to 0 would actually result in solving for 0 particles, likely not the desired/expected behavior.